### PR TITLE
fix(ui): dedupe underlying models, add Routes-to column

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -230,8 +230,23 @@ function renderProfiles(sectionId, profiles, includeGeo) {
     tr.appendChild(tdId);
 
     const tdModels = document.createElement("td");
-    tdModels.appendChild(tagList(p.models));
+    tdModels.appendChild(tagList(uniq(p.models)));
     tr.appendChild(tdModels);
+
+    const tdRoutes = document.createElement("td");
+    const routes = uniq(p.routeRegions);
+    if (routes.length === 0 && p.profileId?.startsWith("global.")) {
+      const div = document.createElement("div");
+      div.className = "tags";
+      const span = document.createElement("span");
+      span.className = "tag routes-all";
+      span.textContent = "All commercial regions";
+      div.appendChild(span);
+      tdRoutes.appendChild(div);
+    } else {
+      tdRoutes.appendChild(tagList(routes));
+    }
+    tr.appendChild(tdRoutes);
 
     tbody.appendChild(tr);
     shown++;
@@ -243,13 +258,25 @@ function renderProfiles(sectionId, profiles, includeGeo) {
 function tagList(items) {
   const div = document.createElement("div");
   div.className = "tags";
-  for (const it of items ?? []) {
+  if (!items || items.length === 0) {
+    const em = document.createElement("span");
+    em.className = "tag empty-tag";
+    em.textContent = "—";
+    div.appendChild(em);
+    return div;
+  }
+  for (const it of items) {
     const span = document.createElement("span");
     span.className = "tag";
     span.textContent = it;
     div.appendChild(span);
   }
   return div;
+}
+
+function uniq(items) {
+  if (!Array.isArray(items)) return [];
+  return [...new Set(items)].sort();
 }
 
 function toggleEmpty(sectionId, empty) {

--- a/public/data.json
+++ b/public/data.json
@@ -1074,9 +1074,12 @@
           "description": "Routes requests to Amazon Nova 2 Lite in us-west-2, us-east-1 and us-east-2.",
           "geo": "us",
           "models": [
-            "amazon.nova-2-lite-v1:0",
-            "amazon.nova-2-lite-v1:0",
             "amazon.nova-2-lite-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -1085,9 +1088,12 @@
           "description": "Routes requests to Nova Lite in us-west-2, us-east-1 and us-east-2.",
           "geo": "us",
           "models": [
-            "amazon.nova-lite-v1:0",
-            "amazon.nova-lite-v1:0",
             "amazon.nova-lite-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -1096,9 +1102,12 @@
           "description": "Routes requests to Nova Micro in us-west-2, us-east-1 and us-east-2.",
           "geo": "us",
           "models": [
-            "amazon.nova-micro-v1:0",
-            "amazon.nova-micro-v1:0",
             "amazon.nova-micro-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -1107,9 +1116,12 @@
           "description": "Routes requests to Nova Premier in us-east-1, us-west-2 and us-east-2.",
           "geo": "us",
           "models": [
-            "amazon.nova-premier-v1:0",
-            "amazon.nova-premier-v1:0",
             "amazon.nova-premier-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -1118,9 +1130,12 @@
           "description": "Routes requests to Nova Pro in us-east-2, us-east-1 and us-west-2.",
           "geo": "us",
           "models": [
-            "amazon.nova-pro-v1:0",
-            "amazon.nova-pro-v1:0",
             "amazon.nova-pro-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -1129,9 +1144,12 @@
           "description": "Routes requests to US Anthropic Claude 3.5 Haiku in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "anthropic.claude-3-5-haiku-20241022-v1:0",
-            "anthropic.claude-3-5-haiku-20241022-v1:0",
             "anthropic.claude-3-5-haiku-20241022-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -1140,9 +1158,12 @@
           "description": "Routes requests to Anthropic Claude 3.7 Sonnet in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
             "anthropic.claude-3-7-sonnet-20250219-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -1151,8 +1172,11 @@
           "description": "Routes requests to Anthropic Claude 3 Haiku in us-east-1 and us-west-2.",
           "geo": "us",
           "models": [
-            "anthropic.claude-3-haiku-20240307-v1:0",
             "anthropic.claude-3-haiku-20240307-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-west-2"
           ]
         },
         {
@@ -1161,8 +1185,11 @@
           "description": "Routes requests to Anthropic Cluade 3 Opus in us-east-1 and us-west-2.",
           "geo": "us",
           "models": [
-            "anthropic.claude-3-opus-20240229-v1:0",
             "anthropic.claude-3-opus-20240229-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-west-2"
           ]
         },
         {
@@ -1171,8 +1198,11 @@
           "description": "Routes requests to Anthropic Claude 3 Sonnet in us-east-1 and us-west-2.",
           "geo": "us",
           "models": [
-            "anthropic.claude-3-sonnet-20240229-v1:0",
             "anthropic.claude-3-sonnet-20240229-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-west-2"
           ]
         },
         {
@@ -1181,9 +1211,12 @@
           "description": "Routes requests to Anthropic Claude Haiku 4.5 in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
             "anthropic.claude-haiku-4-5-20251001-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -1192,9 +1225,12 @@
           "description": "Routes requests to Claude Opus 4.1 in us-east-1, us-west-2 and us-east-2.",
           "geo": "us",
           "models": [
-            "anthropic.claude-opus-4-1-20250805-v1:0",
-            "anthropic.claude-opus-4-1-20250805-v1:0",
             "anthropic.claude-opus-4-1-20250805-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -1203,9 +1239,12 @@
           "description": "Routes requests to Claude Opus 4 in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "anthropic.claude-opus-4-20250514-v1:0",
-            "anthropic.claude-opus-4-20250514-v1:0",
             "anthropic.claude-opus-4-20250514-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -1214,9 +1253,12 @@
           "description": "Routes requests to Anthropic Claude Opus 4.5 in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "anthropic.claude-opus-4-5-20251101-v1:0",
-            "anthropic.claude-opus-4-5-20251101-v1:0",
             "anthropic.claude-opus-4-5-20251101-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -1225,9 +1267,12 @@
           "description": "Routes requests to Anthropic Claude Opus 4.6 in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "anthropic.claude-opus-4-6-v1",
-            "anthropic.claude-opus-4-6-v1",
             "anthropic.claude-opus-4-6-v1"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -1236,9 +1281,12 @@
           "description": "Routes requests to Anthropic Claude Opus 4.7 in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "anthropic.claude-opus-4-7",
-            "anthropic.claude-opus-4-7",
             "anthropic.claude-opus-4-7"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -1247,9 +1295,12 @@
           "description": "Routes requests to Claude Sonnet 4 in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
             "anthropic.claude-sonnet-4-20250514-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -1258,9 +1309,12 @@
           "description": "Routes requests to Anthropic Claude Sonnet 4.5 in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
             "anthropic.claude-sonnet-4-5-20250929-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -1269,9 +1323,12 @@
           "description": "Routes requests to Claude Sonnet 4.6 in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "anthropic.claude-sonnet-4-6",
-            "anthropic.claude-sonnet-4-6",
             "anthropic.claude-sonnet-4-6"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -1280,9 +1337,12 @@
           "description": "Routes requests to Embed v4 in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "cohere.embed-v4:0",
-            "cohere.embed-v4:0",
             "cohere.embed-v4:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -1291,9 +1351,12 @@
           "description": "Routes requests to DeepSeek-R1 in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "deepseek.r1-v1:0",
-            "deepseek.r1-v1:0",
             "deepseek.r1-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -1302,9 +1365,12 @@
           "description": "Routes requests to Meta Llama 3.1 70B Instruct in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "meta.llama3-1-70b-instruct-v1:0",
-            "meta.llama3-1-70b-instruct-v1:0",
             "meta.llama3-1-70b-instruct-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -1313,9 +1379,12 @@
           "description": "Routes requests to Meta Llama 3.1 8B Instruct in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "meta.llama3-1-8b-instruct-v1:0",
-            "meta.llama3-1-8b-instruct-v1:0",
             "meta.llama3-1-8b-instruct-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -1324,8 +1393,11 @@
           "description": "Routes requests to Meta Llama 3.2 11B Instruct in us-east-1 and us-west-2.",
           "geo": "us",
           "models": [
-            "meta.llama3-2-11b-instruct-v1:0",
             "meta.llama3-2-11b-instruct-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-west-2"
           ]
         },
         {
@@ -1334,8 +1406,11 @@
           "description": "Routes requests to Meta Llama 3.2 1B Instruct in us-east-1 and us-west-2.",
           "geo": "us",
           "models": [
-            "meta.llama3-2-1b-instruct-v1:0",
             "meta.llama3-2-1b-instruct-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-west-2"
           ]
         },
         {
@@ -1344,8 +1419,11 @@
           "description": "Routes requests to Meta Llama 3.2 3B Instruct in us-east-1 and us-west-2.",
           "geo": "us",
           "models": [
-            "meta.llama3-2-3b-instruct-v1:0",
             "meta.llama3-2-3b-instruct-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-west-2"
           ]
         },
         {
@@ -1354,8 +1432,11 @@
           "description": "Routes requests to Meta Llama 3.2 90B Instruct in us-east-1 and us-west-2.",
           "geo": "us",
           "models": [
-            "meta.llama3-2-90b-instruct-v1:0",
             "meta.llama3-2-90b-instruct-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-west-2"
           ]
         },
         {
@@ -1364,9 +1445,12 @@
           "description": "Routes requests to Meta Llama 3.3 70B Instruct in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "meta.llama3-3-70b-instruct-v1:0",
-            "meta.llama3-3-70b-instruct-v1:0",
             "meta.llama3-3-70b-instruct-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -1375,9 +1459,12 @@
           "description": "Routes requests to Llama 4 Maverick 17B Instruct in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "meta.llama4-maverick-17b-instruct-v1:0",
-            "meta.llama4-maverick-17b-instruct-v1:0",
             "meta.llama4-maverick-17b-instruct-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -1386,9 +1473,12 @@
           "description": "Routes requests to Llama 4 Scout 17B Instruct in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "meta.llama4-scout-17b-instruct-v1:0",
-            "meta.llama4-scout-17b-instruct-v1:0",
             "meta.llama4-scout-17b-instruct-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -1397,9 +1487,12 @@
           "description": "Routes requests to Mistral Pixtral Large 25.02 in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "mistral.pixtral-large-2502-v1:0",
-            "mistral.pixtral-large-2502-v1:0",
             "mistral.pixtral-large-2502-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -1408,9 +1501,12 @@
           "description": "Routes requests to Stable Image Conservative Upscale in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "stability.stable-conservative-upscale-v1:0",
-            "stability.stable-conservative-upscale-v1:0",
             "stability.stable-conservative-upscale-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -1419,9 +1515,12 @@
           "description": "Routes requests to Stable Image Creative Upscale in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "stability.stable-creative-upscale-v1:0",
-            "stability.stable-creative-upscale-v1:0",
             "stability.stable-creative-upscale-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -1430,9 +1529,12 @@
           "description": "Routes requests to Stable Image Fast Upscale in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "stability.stable-fast-upscale-v1:0",
-            "stability.stable-fast-upscale-v1:0",
             "stability.stable-fast-upscale-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -1441,9 +1543,12 @@
           "description": "Routes requests to Stable Image Control Sketch in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "stability.stable-image-control-sketch-v1:0",
-            "stability.stable-image-control-sketch-v1:0",
             "stability.stable-image-control-sketch-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -1452,9 +1557,12 @@
           "description": "Routes requests to Stable Image Control Structure in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "stability.stable-image-control-structure-v1:0",
-            "stability.stable-image-control-structure-v1:0",
             "stability.stable-image-control-structure-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -1463,9 +1571,12 @@
           "description": "Routes requests to Stable Image Erase Object in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "stability.stable-image-erase-object-v1:0",
-            "stability.stable-image-erase-object-v1:0",
             "stability.stable-image-erase-object-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -1474,9 +1585,12 @@
           "description": "Routes requests to Stable Image Inpaint in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "stability.stable-image-inpaint-v1:0",
-            "stability.stable-image-inpaint-v1:0",
             "stability.stable-image-inpaint-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -1485,9 +1599,12 @@
           "description": "Routes requests to Stable Image Remove Background in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "stability.stable-image-remove-background-v1:0",
-            "stability.stable-image-remove-background-v1:0",
             "stability.stable-image-remove-background-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -1496,9 +1613,12 @@
           "description": "Routes requests to Stable Image Search and Recolor in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "stability.stable-image-search-recolor-v1:0",
-            "stability.stable-image-search-recolor-v1:0",
             "stability.stable-image-search-recolor-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -1507,9 +1627,12 @@
           "description": "Routes requests to Stable Image Search and Replace in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "stability.stable-image-search-replace-v1:0",
-            "stability.stable-image-search-replace-v1:0",
             "stability.stable-image-search-replace-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -1518,9 +1641,12 @@
           "description": "Routes requests to Stable Image Style Guide in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "stability.stable-image-style-guide-v1:0",
-            "stability.stable-image-style-guide-v1:0",
             "stability.stable-image-style-guide-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -1529,9 +1655,12 @@
           "description": "Routes requests to Stable Image Outpaint in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "stability.stable-outpaint-v1:0",
-            "stability.stable-outpaint-v1:0",
             "stability.stable-outpaint-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -1540,9 +1669,12 @@
           "description": "Routes requests to Stable Image Style Transfer in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "stability.stable-style-transfer-v1:0",
-            "stability.stable-style-transfer-v1:0",
             "stability.stable-style-transfer-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -1551,10 +1683,13 @@
           "description": "Routes requests to TwelveLabs Marengo Embed v2.7 in us-east-1, us-east-2, us-west-2 and us-west-1.",
           "geo": "us",
           "models": [
-            "twelvelabs.marengo-embed-2-7-v1:0",
-            "twelvelabs.marengo-embed-2-7-v1:0",
-            "twelvelabs.marengo-embed-2-7-v1:0",
             "twelvelabs.marengo-embed-2-7-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-1",
+            "us-west-2"
           ]
         },
         {
@@ -1563,9 +1698,12 @@
           "description": "Routes requests to Marengo Embed 3.0 in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "twelvelabs.marengo-embed-3-0-v1:0",
-            "twelvelabs.marengo-embed-3-0-v1:0",
             "twelvelabs.marengo-embed-3-0-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -1574,10 +1712,13 @@
           "description": "Routes requests to Pegasus v1.2 in us-east-1, us-east-2, us-west-1, us-west-2.",
           "geo": "us",
           "models": [
-            "twelvelabs.pegasus-1-2-v1:0",
-            "twelvelabs.pegasus-1-2-v1:0",
-            "twelvelabs.pegasus-1-2-v1:0",
             "twelvelabs.pegasus-1-2-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-1",
+            "us-west-2"
           ]
         },
         {
@@ -1586,9 +1727,12 @@
           "description": "Routes requests to Palmyra X4 in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "writer.palmyra-x4-v1:0",
-            "writer.palmyra-x4-v1:0",
             "writer.palmyra-x4-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -1597,9 +1741,12 @@
           "description": "Routes requests to Palmyra X5 in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "writer.palmyra-x5-v1:0",
-            "writer.palmyra-x5-v1:0",
             "writer.palmyra-x5-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         }
       ],
@@ -1609,90 +1756,90 @@
           "profileName": "GLOBAL Amazon Nova 2 Lite",
           "description": "Routes requests to Amazon Nova 2 Lite globally across all supported AWS Regions.",
           "models": [
-            "amazon.nova-2-lite-v1:0",
             "amazon.nova-2-lite-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
           "profileName": "Global Anthropic Claude Haiku 4.5",
           "description": "Routes requests to Anthropic Claude Haiku 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
             "anthropic.claude-haiku-4-5-20251001-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-5-20251101-v1:0",
           "profileName": "GLOBAL Anthropic Claude Opus 4.5",
           "description": "Routes requests to Anthropic Claude Opus 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-5-20251101-v1:0",
             "anthropic.claude-opus-4-5-20251101-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-6-v1",
           "profileName": "Global Anthropic Claude Opus 4.6",
           "description": "Routes requests to Anthropic Claude Opus 4.6 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-6-v1",
             "anthropic.claude-opus-4-6-v1"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-7",
           "profileName": "Global Anthropic Claude Opus 4.7",
           "description": "Routes requests to Anthropic Claude Opus 4.7 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-7",
             "anthropic.claude-opus-4-7"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-sonnet-4-20250514-v1:0",
           "profileName": "Global Claude Sonnet 4",
           "description": "Routes requests to Claude Sonnet 4 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-sonnet-4-20250514-v1:0",
             "anthropic.claude-sonnet-4-20250514-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
           "profileName": "Global Claude Sonnet 4.5",
           "description": "Routes requests to Claude Sonnet 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
             "anthropic.claude-sonnet-4-5-20250929-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-sonnet-4-6",
           "profileName": "Global Anthropic Claude Sonnet 4.6",
           "description": "Routes requests to Anthropic Claude Sonnet 4.6 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-sonnet-4-6",
             "anthropic.claude-sonnet-4-6"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.cohere.embed-v4:0",
           "profileName": "Global Cohere Embed v4",
           "description": "Routes requests to Embed v4 globally across all supported AWS Regions.",
           "models": [
-            "cohere.embed-v4:0",
             "cohere.embed-v4:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.twelvelabs.pegasus-1-2-v1:0",
           "profileName": "GLOBAL TwelveLabs Pegasus v1.2",
           "description": "Routes requests to Pegasus v1.2 globally across all supported AWS Regions.",
           "models": [
-            "twelvelabs.pegasus-1-2-v1:0",
             "twelvelabs.pegasus-1-2-v1:0"
-          ]
+          ],
+          "routeRegions": []
         }
       ]
     },
@@ -2291,9 +2438,12 @@
           "description": "Routes requests to Amazon Nova 2 Lite in us-west-2, us-east-1 and us-east-2.",
           "geo": "us",
           "models": [
-            "amazon.nova-2-lite-v1:0",
-            "amazon.nova-2-lite-v1:0",
             "amazon.nova-2-lite-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -2302,9 +2452,12 @@
           "description": "Routes requests to Nova Lite in us-west-2, us-east-1 and us-east-2.",
           "geo": "us",
           "models": [
-            "amazon.nova-lite-v1:0",
-            "amazon.nova-lite-v1:0",
             "amazon.nova-lite-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -2313,9 +2466,12 @@
           "description": "Routes requests to Nova Micro in us-east-1, us-west-2 and us-east-2.",
           "geo": "us",
           "models": [
-            "amazon.nova-micro-v1:0",
-            "amazon.nova-micro-v1:0",
             "amazon.nova-micro-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -2324,9 +2480,12 @@
           "description": "Routes requests to Nova Premier in us-east-1, us-west-2 and us-east-2.",
           "geo": "us",
           "models": [
-            "amazon.nova-premier-v1:0",
-            "amazon.nova-premier-v1:0",
             "amazon.nova-premier-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -2335,9 +2494,12 @@
           "description": "Routes requests to Nova Pro in us-east-2, us-east-1 and us-west-2.",
           "geo": "us",
           "models": [
-            "amazon.nova-pro-v1:0",
-            "amazon.nova-pro-v1:0",
             "amazon.nova-pro-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -2346,9 +2508,12 @@
           "description": "Routes requests to Anthropic Claude 3.5 Haiku in us-west-2, us-east-1 and us-east-2.",
           "geo": "us",
           "models": [
-            "anthropic.claude-3-5-haiku-20241022-v1:0",
-            "anthropic.claude-3-5-haiku-20241022-v1:0",
             "anthropic.claude-3-5-haiku-20241022-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -2357,9 +2522,12 @@
           "description": "Routes requests to Anthropic Claude 3.7 Sonnet in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
             "anthropic.claude-3-7-sonnet-20250219-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -2368,9 +2536,12 @@
           "description": "Routes requests to Anthropic Claude 3 Haiku in us-east-1, us-west-2 and us-east-2.",
           "geo": "us",
           "models": [
-            "anthropic.claude-3-haiku-20240307-v1:0",
-            "anthropic.claude-3-haiku-20240307-v1:0",
             "anthropic.claude-3-haiku-20240307-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -2379,9 +2550,12 @@
           "description": "Routes requests to Anthropic Claude Haiku 4.5 in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
             "anthropic.claude-haiku-4-5-20251001-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -2390,9 +2564,12 @@
           "description": "Routes requests to Claude Opus 4.1 in us-east-1, us-west-2 and us-east-2.",
           "geo": "us",
           "models": [
-            "anthropic.claude-opus-4-1-20250805-v1:0",
-            "anthropic.claude-opus-4-1-20250805-v1:0",
             "anthropic.claude-opus-4-1-20250805-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -2401,9 +2578,12 @@
           "description": "Routes requests to Claude Opus 4 in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "anthropic.claude-opus-4-20250514-v1:0",
-            "anthropic.claude-opus-4-20250514-v1:0",
             "anthropic.claude-opus-4-20250514-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -2412,9 +2592,12 @@
           "description": "Routes requests to Anthropic Claude Opus 4.5 in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "anthropic.claude-opus-4-5-20251101-v1:0",
-            "anthropic.claude-opus-4-5-20251101-v1:0",
             "anthropic.claude-opus-4-5-20251101-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -2423,9 +2606,12 @@
           "description": "Routes requests to Anthropic Claude Opus 4.6 in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "anthropic.claude-opus-4-6-v1",
-            "anthropic.claude-opus-4-6-v1",
             "anthropic.claude-opus-4-6-v1"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -2434,9 +2620,12 @@
           "description": "Routes requests to Anthropic Claude Opus 4.7 in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "anthropic.claude-opus-4-7",
-            "anthropic.claude-opus-4-7",
             "anthropic.claude-opus-4-7"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -2445,9 +2634,12 @@
           "description": "Routes requests to Claude Sonnet 4 in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
             "anthropic.claude-sonnet-4-20250514-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -2456,9 +2648,12 @@
           "description": "Routes requests to Anthropic Claude Sonnet 4.5 in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
             "anthropic.claude-sonnet-4-5-20250929-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -2467,9 +2662,12 @@
           "description": "Routes requests to Claude Sonnet 4.6 in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "anthropic.claude-sonnet-4-6",
-            "anthropic.claude-sonnet-4-6",
             "anthropic.claude-sonnet-4-6"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -2478,9 +2676,12 @@
           "description": "Routes requests to Embed v4 in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "cohere.embed-v4:0",
-            "cohere.embed-v4:0",
             "cohere.embed-v4:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -2489,9 +2690,12 @@
           "description": "Routes requests to DeepSeek-R1 in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "deepseek.r1-v1:0",
-            "deepseek.r1-v1:0",
             "deepseek.r1-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -2500,9 +2704,12 @@
           "description": "Routes requests to Meta Llama 3.1 Instruct 405B in us-west-2, us-east-1 and us-east-2.",
           "geo": "us",
           "models": [
-            "meta.llama3-1-405b-instruct-v1:0",
-            "meta.llama3-1-405b-instruct-v1:0",
             "meta.llama3-1-405b-instruct-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -2511,9 +2718,12 @@
           "description": "Routes requests to Meta Llama 3.1 70B Instruct in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "meta.llama3-1-70b-instruct-v1:0",
-            "meta.llama3-1-70b-instruct-v1:0",
             "meta.llama3-1-70b-instruct-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -2522,9 +2732,12 @@
           "description": "Routes requests to Meta Llama 3.1 8B Instruct in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "meta.llama3-1-8b-instruct-v1:0",
-            "meta.llama3-1-8b-instruct-v1:0",
             "meta.llama3-1-8b-instruct-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -2533,9 +2746,12 @@
           "description": "Routes requests to Meta Llama 3.2 11B Instruct in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "meta.llama3-2-11b-instruct-v1:0",
-            "meta.llama3-2-11b-instruct-v1:0",
             "meta.llama3-2-11b-instruct-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -2544,9 +2760,12 @@
           "description": "Routes requests to Meta Llama 3.2 1B Instruct in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "meta.llama3-2-1b-instruct-v1:0",
-            "meta.llama3-2-1b-instruct-v1:0",
             "meta.llama3-2-1b-instruct-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -2555,9 +2774,12 @@
           "description": "Routes requests to Meta Llama 3.2 3B Instruct in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "meta.llama3-2-3b-instruct-v1:0",
-            "meta.llama3-2-3b-instruct-v1:0",
             "meta.llama3-2-3b-instruct-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -2566,9 +2788,12 @@
           "description": "Routes requests to Meta Llama 3.2 90B Instruct in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "meta.llama3-2-90b-instruct-v1:0",
-            "meta.llama3-2-90b-instruct-v1:0",
             "meta.llama3-2-90b-instruct-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -2577,9 +2802,12 @@
           "description": "Routes requests to Meta Llama 3.3 70B Instruct in us-east-2, us-east-1 and us-west-2.",
           "geo": "us",
           "models": [
-            "meta.llama3-3-70b-instruct-v1:0",
-            "meta.llama3-3-70b-instruct-v1:0",
             "meta.llama3-3-70b-instruct-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -2588,9 +2816,12 @@
           "description": "Routes requests to Llama 4 Maverick 17B Instruct in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "meta.llama4-maverick-17b-instruct-v1:0",
-            "meta.llama4-maverick-17b-instruct-v1:0",
             "meta.llama4-maverick-17b-instruct-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -2599,9 +2830,12 @@
           "description": "Routes requests to Llama 4 Scout 17B Instruct in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "meta.llama4-scout-17b-instruct-v1:0",
-            "meta.llama4-scout-17b-instruct-v1:0",
             "meta.llama4-scout-17b-instruct-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -2610,9 +2844,12 @@
           "description": "Routes requests to Mistral Pixtral Large 25.02 in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "mistral.pixtral-large-2502-v1:0",
-            "mistral.pixtral-large-2502-v1:0",
             "mistral.pixtral-large-2502-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -2621,9 +2858,12 @@
           "description": "Routes requests to Stable Image Conservative Upscale in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "stability.stable-conservative-upscale-v1:0",
-            "stability.stable-conservative-upscale-v1:0",
             "stability.stable-conservative-upscale-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -2632,9 +2872,12 @@
           "description": "Routes requests to Stable Image Creative Upscale in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "stability.stable-creative-upscale-v1:0",
-            "stability.stable-creative-upscale-v1:0",
             "stability.stable-creative-upscale-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -2643,9 +2886,12 @@
           "description": "Routes requests to Stable Image Fast Upscale in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "stability.stable-fast-upscale-v1:0",
-            "stability.stable-fast-upscale-v1:0",
             "stability.stable-fast-upscale-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -2654,9 +2900,12 @@
           "description": "Routes requests to Stable Image Control Sketch in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "stability.stable-image-control-sketch-v1:0",
-            "stability.stable-image-control-sketch-v1:0",
             "stability.stable-image-control-sketch-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -2665,9 +2914,12 @@
           "description": "Routes requests to Stable Image Control Structure in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "stability.stable-image-control-structure-v1:0",
-            "stability.stable-image-control-structure-v1:0",
             "stability.stable-image-control-structure-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -2676,9 +2928,12 @@
           "description": "Routes requests to Stable Image Erase Object in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "stability.stable-image-erase-object-v1:0",
-            "stability.stable-image-erase-object-v1:0",
             "stability.stable-image-erase-object-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -2687,9 +2942,12 @@
           "description": "Routes requests to Stable Image Inpaint in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "stability.stable-image-inpaint-v1:0",
-            "stability.stable-image-inpaint-v1:0",
             "stability.stable-image-inpaint-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -2698,9 +2956,12 @@
           "description": "Routes requests to Stable Image Remove Background in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "stability.stable-image-remove-background-v1:0",
-            "stability.stable-image-remove-background-v1:0",
             "stability.stable-image-remove-background-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -2709,9 +2970,12 @@
           "description": "Routes requests to Stable Image Search and Recolor in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "stability.stable-image-search-recolor-v1:0",
-            "stability.stable-image-search-recolor-v1:0",
             "stability.stable-image-search-recolor-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -2720,9 +2984,12 @@
           "description": "Routes requests to Stable Image Search and Replace in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "stability.stable-image-search-replace-v1:0",
-            "stability.stable-image-search-replace-v1:0",
             "stability.stable-image-search-replace-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -2731,9 +2998,12 @@
           "description": "Routes requests to Stable Image Style Guide in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "stability.stable-image-style-guide-v1:0",
-            "stability.stable-image-style-guide-v1:0",
             "stability.stable-image-style-guide-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -2742,9 +3012,12 @@
           "description": "Routes requests to Stable Image Outpaint in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "stability.stable-outpaint-v1:0",
-            "stability.stable-outpaint-v1:0",
             "stability.stable-outpaint-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -2753,9 +3026,12 @@
           "description": "Routes requests to Stable Image Style Transfer in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "stability.stable-style-transfer-v1:0",
-            "stability.stable-style-transfer-v1:0",
             "stability.stable-style-transfer-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -2764,9 +3040,12 @@
           "description": "Routes requests to Pegasus v1.2 in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "twelvelabs.pegasus-1-2-v1:0",
-            "twelvelabs.pegasus-1-2-v1:0",
             "twelvelabs.pegasus-1-2-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -2775,9 +3054,12 @@
           "description": "Routes requests to Palmyra X4 in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "writer.palmyra-x4-v1:0",
-            "writer.palmyra-x4-v1:0",
             "writer.palmyra-x4-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -2786,9 +3068,12 @@
           "description": "Routes requests to Palmyra X5 in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "writer.palmyra-x5-v1:0",
-            "writer.palmyra-x5-v1:0",
             "writer.palmyra-x5-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         }
       ],
@@ -2798,90 +3083,90 @@
           "profileName": "GLOBAL Amazon Nova 2 Lite",
           "description": "Routes requests to Amazon Nova 2 Lite globally across all supported AWS Regions.",
           "models": [
-            "amazon.nova-2-lite-v1:0",
             "amazon.nova-2-lite-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
           "profileName": "Global Anthropic Claude Haiku 4.5",
           "description": "Routes requests to Anthropic Claude Haiku 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
             "anthropic.claude-haiku-4-5-20251001-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-5-20251101-v1:0",
           "profileName": "GLOBAL Anthropic Claude Opus 4.5",
           "description": "Routes requests to Anthropic Claude Opus 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-5-20251101-v1:0",
             "anthropic.claude-opus-4-5-20251101-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-6-v1",
           "profileName": "Global Anthropic Claude Opus 4.6",
           "description": "Routes requests to Anthropic Claude Opus 4.6 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-6-v1",
             "anthropic.claude-opus-4-6-v1"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-7",
           "profileName": "Global Anthropic Claude Opus 4.7",
           "description": "Routes requests to Anthropic Claude Opus 4.7 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-7",
             "anthropic.claude-opus-4-7"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-sonnet-4-20250514-v1:0",
           "profileName": "Global Claude Sonnet 4",
           "description": "Routes requests to Claude Sonnet 4 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-sonnet-4-20250514-v1:0",
             "anthropic.claude-sonnet-4-20250514-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
           "profileName": "Global Claude Sonnet 4.5",
           "description": "Routes requests to Claude Sonnet 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
             "anthropic.claude-sonnet-4-5-20250929-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-sonnet-4-6",
           "profileName": "Global Anthropic Claude Sonnet 4.6",
           "description": "Routes requests to Anthropic Claude Sonnet 4.6 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-sonnet-4-6",
             "anthropic.claude-sonnet-4-6"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.cohere.embed-v4:0",
           "profileName": "Global Cohere Embed v4",
           "description": "Routes requests to Embed v4 globally across all supported AWS Regions.",
           "models": [
-            "cohere.embed-v4:0",
             "cohere.embed-v4:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.twelvelabs.pegasus-1-2-v1:0",
           "profileName": "GLOBAL TwelveLabs Pegasus v1.2",
           "description": "Routes requests to Pegasus v1.2 globally across all supported AWS Regions.",
           "models": [
-            "twelvelabs.pegasus-1-2-v1:0",
             "twelvelabs.pegasus-1-2-v1:0"
-          ]
+          ],
+          "routeRegions": []
         }
       ]
     },
@@ -2894,10 +3179,13 @@
           "description": "Routes requests to Amazon Nova 2 Lite in us-east-1, us-east-2, us-west-1 and us-west-2.",
           "geo": "us",
           "models": [
-            "amazon.nova-2-lite-v1:0",
-            "amazon.nova-2-lite-v1:0",
-            "amazon.nova-2-lite-v1:0",
             "amazon.nova-2-lite-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-1",
+            "us-west-2"
           ]
         },
         {
@@ -2906,10 +3194,13 @@
           "description": "Routes requests to Nova Lite in us-east-1, us-west-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "amazon.nova-lite-v1:0",
-            "amazon.nova-lite-v1:0",
-            "amazon.nova-lite-v1:0",
             "amazon.nova-lite-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-1",
+            "us-west-2"
           ]
         },
         {
@@ -2918,10 +3209,13 @@
           "description": "Routes requests to Nova Pro in us-east-1, us-east-2, us-west-1 and us-west-2.",
           "geo": "us",
           "models": [
-            "amazon.nova-pro-v1:0",
-            "amazon.nova-pro-v1:0",
-            "amazon.nova-pro-v1:0",
             "amazon.nova-pro-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-1",
+            "us-west-2"
           ]
         },
         {
@@ -2930,10 +3224,13 @@
           "description": "Routes requests to Anthropic Claude Haiku 4.5 in us-east-1, us-east-2, us-west-2 and us-west-1.",
           "geo": "us",
           "models": [
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
             "anthropic.claude-haiku-4-5-20251001-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-1",
+            "us-west-2"
           ]
         },
         {
@@ -2942,10 +3239,13 @@
           "description": "Routes requests to Anthropic Claude Opus 4.5 in us-east-1, us-east-2, us-west-2 and us-west-1.",
           "geo": "us",
           "models": [
-            "anthropic.claude-opus-4-5-20251101-v1:0",
-            "anthropic.claude-opus-4-5-20251101-v1:0",
-            "anthropic.claude-opus-4-5-20251101-v1:0",
             "anthropic.claude-opus-4-5-20251101-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-1",
+            "us-west-2"
           ]
         },
         {
@@ -2954,10 +3254,13 @@
           "description": "Routes requests to Anthropic Claude Opus 4.6 in us-east-1, us-east-2, us-west-2 and us-west-1.",
           "geo": "us",
           "models": [
-            "anthropic.claude-opus-4-6-v1",
-            "anthropic.claude-opus-4-6-v1",
-            "anthropic.claude-opus-4-6-v1",
             "anthropic.claude-opus-4-6-v1"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-1",
+            "us-west-2"
           ]
         },
         {
@@ -2966,10 +3269,13 @@
           "description": "Routes requests to Anthropic Claude Opus 4.7 in us-east-1, us-east-2, us-west-1 and us-west-2.",
           "geo": "us",
           "models": [
-            "anthropic.claude-opus-4-7",
-            "anthropic.claude-opus-4-7",
-            "anthropic.claude-opus-4-7",
             "anthropic.claude-opus-4-7"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-1",
+            "us-west-2"
           ]
         },
         {
@@ -2978,10 +3284,13 @@
           "description": "Routes requests to Claude Sonnet 4 in us-east-1, us-east-2, us-west-1 and us-west-2.",
           "geo": "us",
           "models": [
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
             "anthropic.claude-sonnet-4-20250514-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-1",
+            "us-west-2"
           ]
         },
         {
@@ -2990,10 +3299,13 @@
           "description": "Routes requests to Anthropic Claude Sonnet 4.5 in us-east-1, us-east-2, us-west-2 and us-west-1.",
           "geo": "us",
           "models": [
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
             "anthropic.claude-sonnet-4-5-20250929-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-1",
+            "us-west-2"
           ]
         },
         {
@@ -3002,10 +3314,13 @@
           "description": "Routes requests to Claude Sonnet 4.6 in us-east-1, us-east-2, us-west-1, us-west-2.",
           "geo": "us",
           "models": [
-            "anthropic.claude-sonnet-4-6",
-            "anthropic.claude-sonnet-4-6",
-            "anthropic.claude-sonnet-4-6",
             "anthropic.claude-sonnet-4-6"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-1",
+            "us-west-2"
           ]
         },
         {
@@ -3014,10 +3329,13 @@
           "description": "Routes requests to Embed v4 in us-east-1, us-east-2, us-west-1, us-west-2.",
           "geo": "us",
           "models": [
-            "cohere.embed-v4:0",
-            "cohere.embed-v4:0",
-            "cohere.embed-v4:0",
             "cohere.embed-v4:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-1",
+            "us-west-2"
           ]
         },
         {
@@ -3026,10 +3344,13 @@
           "description": "Routes requests to US Llama 4 Maverick 17B Instruct in us-east-1, us-east-2, us-west-1 and us-west-2.",
           "geo": "us",
           "models": [
-            "meta.llama4-maverick-17b-instruct-v1:0",
-            "meta.llama4-maverick-17b-instruct-v1:0",
-            "meta.llama4-maverick-17b-instruct-v1:0",
             "meta.llama4-maverick-17b-instruct-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-1",
+            "us-west-2"
           ]
         },
         {
@@ -3038,10 +3359,13 @@
           "description": "Routes requests to US Llama 4 Scout 17B Instruct in us-east-1, us-east-2, us-west-1 and us-west-2.",
           "geo": "us",
           "models": [
-            "meta.llama4-scout-17b-instruct-v1:0",
-            "meta.llama4-scout-17b-instruct-v1:0",
-            "meta.llama4-scout-17b-instruct-v1:0",
             "meta.llama4-scout-17b-instruct-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-1",
+            "us-west-2"
           ]
         },
         {
@@ -3050,10 +3374,13 @@
           "description": "Routes requests to Pegasus v1.2 in us-east-1, us-east-2, us-west-1, us-west-2.",
           "geo": "us",
           "models": [
-            "twelvelabs.pegasus-1-2-v1:0",
-            "twelvelabs.pegasus-1-2-v1:0",
-            "twelvelabs.pegasus-1-2-v1:0",
             "twelvelabs.pegasus-1-2-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-1",
+            "us-west-2"
           ]
         },
         {
@@ -3062,10 +3389,13 @@
           "description": "Routes requests to Palmyra X4 in us-east-1, us-east-2, us-west-1, us-west-2.",
           "geo": "us",
           "models": [
-            "writer.palmyra-x4-v1:0",
-            "writer.palmyra-x4-v1:0",
-            "writer.palmyra-x4-v1:0",
             "writer.palmyra-x4-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-1",
+            "us-west-2"
           ]
         },
         {
@@ -3074,10 +3404,13 @@
           "description": "Routes requests to Palmyra X5 in us-east-1, us-east-2, us-west-1, us-west-2.",
           "geo": "us",
           "models": [
-            "writer.palmyra-x5-v1:0",
-            "writer.palmyra-x5-v1:0",
-            "writer.palmyra-x5-v1:0",
             "writer.palmyra-x5-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-1",
+            "us-west-2"
           ]
         }
       ],
@@ -3087,81 +3420,81 @@
           "profileName": "GLOBAL Amazon Nova 2 Lite",
           "description": "Routes requests to Amazon Nova 2 Lite globally across all supported AWS Regions.",
           "models": [
-            "amazon.nova-2-lite-v1:0",
             "amazon.nova-2-lite-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
           "profileName": "Global Anthropic Claude Haiku 4.5",
           "description": "Routes requests to Anthropic Claude Haiku 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
             "anthropic.claude-haiku-4-5-20251001-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-5-20251101-v1:0",
           "profileName": "GLOBAL Anthropic Claude Opus 4.5",
           "description": "Routes requests to Anthropic Claude Opus 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-5-20251101-v1:0",
             "anthropic.claude-opus-4-5-20251101-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-6-v1",
           "profileName": "Global Anthropic Claude Opus 4.6",
           "description": "Routes requests to Anthropic Claude Opus 4.6 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-6-v1",
             "anthropic.claude-opus-4-6-v1"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-7",
           "profileName": "Global Anthropic Claude Opus 4.7",
           "description": "Routes requests to Anthropic Claude Opus 4.7 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-7",
             "anthropic.claude-opus-4-7"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
           "profileName": "Global Claude Sonnet 4.5",
           "description": "Routes requests to Claude Sonnet 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
             "anthropic.claude-sonnet-4-5-20250929-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-sonnet-4-6",
           "profileName": "Global Anthropic Claude Sonnet 4.6",
           "description": "Routes requests to Claude Sonnet 4.6 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-sonnet-4-6",
             "anthropic.claude-sonnet-4-6"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.cohere.embed-v4:0",
           "profileName": "Global Cohere Embed v4",
           "description": "Routes requests to Embed v4 globally across all supported AWS Regions.",
           "models": [
-            "cohere.embed-v4:0",
             "cohere.embed-v4:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.twelvelabs.pegasus-1-2-v1:0",
           "profileName": "GLOBAL TwelveLabs Pegasus v1.2",
           "description": "Routes requests to Pegasus v1.2 globally across all supported AWS Regions.",
           "models": [
-            "twelvelabs.pegasus-1-2-v1:0",
             "twelvelabs.pegasus-1-2-v1:0"
-          ]
+          ],
+          "routeRegions": []
         }
       ]
     },
@@ -4167,9 +4500,12 @@
           "description": "Routes requests to Amazon Nova 2 Lite in us-west-2, us-east-1 and us-east-2.",
           "geo": "us",
           "models": [
-            "amazon.nova-2-lite-v1:0",
-            "amazon.nova-2-lite-v1:0",
             "amazon.nova-2-lite-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -4178,9 +4514,12 @@
           "description": "Routes requests to Nova Lite in us-west-2, us-east-1 and us-east-2.",
           "geo": "us",
           "models": [
-            "amazon.nova-lite-v1:0",
-            "amazon.nova-lite-v1:0",
             "amazon.nova-lite-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -4189,9 +4528,12 @@
           "description": "Routes requests to Nova Micro in us-west-2, us-east-1 and us-east-2.",
           "geo": "us",
           "models": [
-            "amazon.nova-micro-v1:0",
-            "amazon.nova-micro-v1:0",
             "amazon.nova-micro-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -4200,9 +4542,12 @@
           "description": "Routes requests to Nova Premier in us-east-1, us-west-2 and us-east-2.",
           "geo": "us",
           "models": [
-            "amazon.nova-premier-v1:0",
-            "amazon.nova-premier-v1:0",
             "amazon.nova-premier-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -4211,9 +4556,12 @@
           "description": "Routes requests to Nova Pro in us-east-2, us-east-1 and us-west-2.",
           "geo": "us",
           "models": [
-            "amazon.nova-pro-v1:0",
-            "amazon.nova-pro-v1:0",
             "amazon.nova-pro-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -4222,9 +4570,12 @@
           "description": "Routes requests to Anthropic Claude 3.5 Haiku in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "anthropic.claude-3-5-haiku-20241022-v1:0",
-            "anthropic.claude-3-5-haiku-20241022-v1:0",
             "anthropic.claude-3-5-haiku-20241022-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -4233,9 +4584,12 @@
           "description": "Routes requests to Anthropic Claude 3.7 Sonnet in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
             "anthropic.claude-3-7-sonnet-20250219-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -4244,8 +4598,11 @@
           "description": "Routes requests to Anthropic Claude 3 Haiku in us-east-1 and us-west-2.",
           "geo": "us",
           "models": [
-            "anthropic.claude-3-haiku-20240307-v1:0",
             "anthropic.claude-3-haiku-20240307-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-west-2"
           ]
         },
         {
@@ -4254,8 +4611,11 @@
           "description": "Routes requests to Anthropic Cluade 3 Opus in us-east-1 and us-west-2.",
           "geo": "us",
           "models": [
-            "anthropic.claude-3-opus-20240229-v1:0",
             "anthropic.claude-3-opus-20240229-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-west-2"
           ]
         },
         {
@@ -4264,8 +4624,11 @@
           "description": "Routes requests to Anthropic Claude 3 Sonnet in us-east-1 and us-west-2.",
           "geo": "us",
           "models": [
-            "anthropic.claude-3-sonnet-20240229-v1:0",
             "anthropic.claude-3-sonnet-20240229-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-west-2"
           ]
         },
         {
@@ -4274,9 +4637,12 @@
           "description": "Routes requests to Anthropic Claude Haiku 4.5 in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
             "anthropic.claude-haiku-4-5-20251001-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -4285,9 +4651,12 @@
           "description": "Routes requests to Claude Opus 4.1 in us-east-1, us-west-2 and us-east-2.",
           "geo": "us",
           "models": [
-            "anthropic.claude-opus-4-1-20250805-v1:0",
-            "anthropic.claude-opus-4-1-20250805-v1:0",
             "anthropic.claude-opus-4-1-20250805-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -4296,9 +4665,12 @@
           "description": "Routes requests to Claude Opus 4 in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "anthropic.claude-opus-4-20250514-v1:0",
-            "anthropic.claude-opus-4-20250514-v1:0",
             "anthropic.claude-opus-4-20250514-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -4307,9 +4679,12 @@
           "description": "Routes requests to Anthropic Claude Opus 4.5 in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "anthropic.claude-opus-4-5-20251101-v1:0",
-            "anthropic.claude-opus-4-5-20251101-v1:0",
             "anthropic.claude-opus-4-5-20251101-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -4318,9 +4693,12 @@
           "description": "Routes requests to Anthropic Claude Opus 4.6 in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "anthropic.claude-opus-4-6-v1",
-            "anthropic.claude-opus-4-6-v1",
             "anthropic.claude-opus-4-6-v1"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -4329,9 +4707,12 @@
           "description": "Routes requests to Anthropic Claude Opus 4.7 in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "anthropic.claude-opus-4-7",
-            "anthropic.claude-opus-4-7",
             "anthropic.claude-opus-4-7"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -4340,9 +4721,12 @@
           "description": "Routes requests to Claude Sonnet 4 in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
             "anthropic.claude-sonnet-4-20250514-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -4351,9 +4735,12 @@
           "description": "Routes requests to Anthropic Claude Sonnet 4.5 in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
             "anthropic.claude-sonnet-4-5-20250929-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -4362,9 +4749,12 @@
           "description": "Routes requests to Claude Sonnet 4.6 in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "anthropic.claude-sonnet-4-6",
-            "anthropic.claude-sonnet-4-6",
             "anthropic.claude-sonnet-4-6"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -4373,9 +4763,12 @@
           "description": "Routes requests to Embed v4 in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "cohere.embed-v4:0",
-            "cohere.embed-v4:0",
             "cohere.embed-v4:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -4384,9 +4777,12 @@
           "description": "Routes requests to DeepSeek-R1 in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "deepseek.r1-v1:0",
-            "deepseek.r1-v1:0",
             "deepseek.r1-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -4395,9 +4791,12 @@
           "description": "Routes requests to Meta Llama 3.1 70B Instruct in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "meta.llama3-1-70b-instruct-v1:0",
-            "meta.llama3-1-70b-instruct-v1:0",
             "meta.llama3-1-70b-instruct-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -4406,9 +4805,12 @@
           "description": "Routes requests to Meta Llama 3.1 8B Instruct in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "meta.llama3-1-8b-instruct-v1:0",
-            "meta.llama3-1-8b-instruct-v1:0",
             "meta.llama3-1-8b-instruct-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -4417,8 +4819,11 @@
           "description": "Routes requests to Meta Llama 3.2 11B Instruct in us-east-1 and us-west-2.",
           "geo": "us",
           "models": [
-            "meta.llama3-2-11b-instruct-v1:0",
             "meta.llama3-2-11b-instruct-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-west-2"
           ]
         },
         {
@@ -4427,8 +4832,11 @@
           "description": "Routes requests to Meta Llama 3.2 1B Instruct in us-east-1 and us-west-2.",
           "geo": "us",
           "models": [
-            "meta.llama3-2-1b-instruct-v1:0",
             "meta.llama3-2-1b-instruct-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-west-2"
           ]
         },
         {
@@ -4437,8 +4845,11 @@
           "description": "Routes requests to Meta Llama 3.2 3B Instruct in us-east-1 and us-west-2.",
           "geo": "us",
           "models": [
-            "meta.llama3-2-3b-instruct-v1:0",
             "meta.llama3-2-3b-instruct-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-west-2"
           ]
         },
         {
@@ -4447,8 +4858,11 @@
           "description": "Routes requests to Meta Llama 3.2 90B Instruct in us-east-1 and us-west-2.",
           "geo": "us",
           "models": [
-            "meta.llama3-2-90b-instruct-v1:0",
             "meta.llama3-2-90b-instruct-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-west-2"
           ]
         },
         {
@@ -4457,9 +4871,12 @@
           "description": "Routes requests to Meta Llama 3.3 70B Instruct in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "meta.llama3-3-70b-instruct-v1:0",
-            "meta.llama3-3-70b-instruct-v1:0",
             "meta.llama3-3-70b-instruct-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -4468,9 +4885,12 @@
           "description": "Routes requests to Llama 4 Maverick 17B Instruct in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "meta.llama4-maverick-17b-instruct-v1:0",
-            "meta.llama4-maverick-17b-instruct-v1:0",
             "meta.llama4-maverick-17b-instruct-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -4479,9 +4899,12 @@
           "description": "Routes requests to Llama 4 Scout 17B Instruct in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "meta.llama4-scout-17b-instruct-v1:0",
-            "meta.llama4-scout-17b-instruct-v1:0",
             "meta.llama4-scout-17b-instruct-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -4490,9 +4913,12 @@
           "description": "Routes requests to Mistral Pixtral Large 25.02 in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "mistral.pixtral-large-2502-v1:0",
-            "mistral.pixtral-large-2502-v1:0",
             "mistral.pixtral-large-2502-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -4501,9 +4927,12 @@
           "description": "Routes requests to Stable Image Conservative Upscale in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "stability.stable-conservative-upscale-v1:0",
-            "stability.stable-conservative-upscale-v1:0",
             "stability.stable-conservative-upscale-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -4512,9 +4941,12 @@
           "description": "Routes requests to Stable Image Creative Upscale in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "stability.stable-creative-upscale-v1:0",
-            "stability.stable-creative-upscale-v1:0",
             "stability.stable-creative-upscale-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -4523,9 +4955,12 @@
           "description": "Routes requests to Stable Image Fast Upscale in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "stability.stable-fast-upscale-v1:0",
-            "stability.stable-fast-upscale-v1:0",
             "stability.stable-fast-upscale-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -4534,9 +4969,12 @@
           "description": "Routes requests to Stable Image Control Sketch in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "stability.stable-image-control-sketch-v1:0",
-            "stability.stable-image-control-sketch-v1:0",
             "stability.stable-image-control-sketch-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -4545,9 +4983,12 @@
           "description": "Routes requests to Stable Image Control Structure in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "stability.stable-image-control-structure-v1:0",
-            "stability.stable-image-control-structure-v1:0",
             "stability.stable-image-control-structure-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -4556,9 +4997,12 @@
           "description": "Routes requests to Stable Image Erase Object in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "stability.stable-image-erase-object-v1:0",
-            "stability.stable-image-erase-object-v1:0",
             "stability.stable-image-erase-object-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -4567,9 +5011,12 @@
           "description": "Routes requests to Stable Image Inpaint in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "stability.stable-image-inpaint-v1:0",
-            "stability.stable-image-inpaint-v1:0",
             "stability.stable-image-inpaint-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -4578,9 +5025,12 @@
           "description": "Routes requests to Stable Image Remove Background in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "stability.stable-image-remove-background-v1:0",
-            "stability.stable-image-remove-background-v1:0",
             "stability.stable-image-remove-background-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -4589,9 +5039,12 @@
           "description": "Routes requests to Stable Image Search and Recolor in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "stability.stable-image-search-recolor-v1:0",
-            "stability.stable-image-search-recolor-v1:0",
             "stability.stable-image-search-recolor-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -4600,9 +5053,12 @@
           "description": "Routes requests to Stable Image Search and Replace in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "stability.stable-image-search-replace-v1:0",
-            "stability.stable-image-search-replace-v1:0",
             "stability.stable-image-search-replace-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -4611,9 +5067,12 @@
           "description": "Routes requests to Stable Image Style Guide in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "stability.stable-image-style-guide-v1:0",
-            "stability.stable-image-style-guide-v1:0",
             "stability.stable-image-style-guide-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -4622,9 +5081,12 @@
           "description": "Routes requests to Stable Image Outpaint in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "stability.stable-outpaint-v1:0",
-            "stability.stable-outpaint-v1:0",
             "stability.stable-outpaint-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -4633,9 +5095,12 @@
           "description": "Routes requests to Stable Image Style Transfer in us-east-1, us-east-2, us-west-2.",
           "geo": "us",
           "models": [
-            "stability.stable-style-transfer-v1:0",
-            "stability.stable-style-transfer-v1:0",
             "stability.stable-style-transfer-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -4644,9 +5109,12 @@
           "description": "Routes requests to TwelveLabs Pegasus v1.2 in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "twelvelabs.pegasus-1-2-v1:0",
-            "twelvelabs.pegasus-1-2-v1:0",
             "twelvelabs.pegasus-1-2-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -4655,9 +5123,12 @@
           "description": "Routes requests to Palmyra X4 in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "writer.palmyra-x4-v1:0",
-            "writer.palmyra-x4-v1:0",
             "writer.palmyra-x4-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -4666,9 +5137,12 @@
           "description": "Routes requests to Palmyra X5 in us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "writer.palmyra-x5-v1:0",
-            "writer.palmyra-x5-v1:0",
             "writer.palmyra-x5-v1:0"
+          ],
+          "routeRegions": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         }
       ],
@@ -4678,90 +5152,90 @@
           "profileName": "GLOBAL Amazon Nova 2 Lite",
           "description": "Routes requests to Amazon Nova 2 Lite globally across all supported AWS Regions.",
           "models": [
-            "amazon.nova-2-lite-v1:0",
             "amazon.nova-2-lite-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
           "profileName": "Global Anthropic Claude Haiku 4.5",
           "description": "Routes requests to Anthropic Claude Haiku 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
             "anthropic.claude-haiku-4-5-20251001-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-5-20251101-v1:0",
           "profileName": "GLOBAL Anthropic Claude Opus 4.5",
           "description": "Routes requests to Anthropic Claude Opus 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-5-20251101-v1:0",
             "anthropic.claude-opus-4-5-20251101-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-6-v1",
           "profileName": "Global Anthropic Claude Opus 4.6",
           "description": "Routes requests to Anthropic Claude Opus 4.6 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-6-v1",
             "anthropic.claude-opus-4-6-v1"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-7",
           "profileName": "Global Anthropic Claude Opus 4.7",
           "description": "Routes requests to Anthropic Claude Opus 4.7 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-7",
             "anthropic.claude-opus-4-7"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-sonnet-4-20250514-v1:0",
           "profileName": "Global Claude Sonnet 4",
           "description": "Routes requests to Claude Sonnet 4 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-sonnet-4-20250514-v1:0",
             "anthropic.claude-sonnet-4-20250514-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
           "profileName": "Global Claude Sonnet 4.5",
           "description": "Routes requests to Claude Sonnet 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
             "anthropic.claude-sonnet-4-5-20250929-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-sonnet-4-6",
           "profileName": "Global Anthropic Claude Sonnet 4.6",
           "description": "Routes requests to Anthropic Claude Sonnet 4.6 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-sonnet-4-6",
             "anthropic.claude-sonnet-4-6"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.cohere.embed-v4:0",
           "profileName": "Global Cohere Embed v4",
           "description": "Routes requests to Embed v4 globally across all supported AWS Regions.",
           "models": [
-            "cohere.embed-v4:0",
             "cohere.embed-v4:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.twelvelabs.pegasus-1-2-v1:0",
           "profileName": "GLOBAL TwelveLabs Pegasus v1.2",
           "description": "Routes requests to Pegasus v1.2 globally across all supported AWS Regions.",
           "models": [
-            "twelvelabs.pegasus-1-2-v1:0",
             "twelvelabs.pegasus-1-2-v1:0"
-          ]
+          ],
+          "routeRegions": []
         }
       ]
     },
@@ -4972,8 +5446,11 @@
           "description": "Routes requests to Nova Lite in ca-central-1 and ca-west-1.",
           "geo": "ca",
           "models": [
-            "amazon.nova-lite-v1:0",
             "amazon.nova-lite-v1:0"
+          ],
+          "routeRegions": [
+            "ca-central-1",
+            "ca-west-1"
           ]
         },
         {
@@ -4982,10 +5459,13 @@
           "description": "Routes requests to Amazon Nova 2 Lite in ca-central-1, us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "amazon.nova-2-lite-v1:0",
-            "amazon.nova-2-lite-v1:0",
-            "amazon.nova-2-lite-v1:0",
             "amazon.nova-2-lite-v1:0"
+          ],
+          "routeRegions": [
+            "ca-central-1",
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -4994,10 +5474,13 @@
           "description": "Routes requests to Anthropic Claude Haiku 4.5 in ca-central-1, us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
             "anthropic.claude-haiku-4-5-20251001-v1:0"
+          ],
+          "routeRegions": [
+            "ca-central-1",
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -5006,10 +5489,13 @@
           "description": "Routes requests to Claude Opus 4.5 in us-east-1, us-east-2, ca-central-1, us-west-2.",
           "geo": "us",
           "models": [
-            "anthropic.claude-opus-4-5-20251101-v1:0",
-            "anthropic.claude-opus-4-5-20251101-v1:0",
-            "anthropic.claude-opus-4-5-20251101-v1:0",
             "anthropic.claude-opus-4-5-20251101-v1:0"
+          ],
+          "routeRegions": [
+            "ca-central-1",
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -5018,10 +5504,13 @@
           "description": "Routes requests to Claude Opus 4.6 in us-east-1, us-east-2, ca-central-1, us-west-2.",
           "geo": "us",
           "models": [
-            "anthropic.claude-opus-4-6-v1",
-            "anthropic.claude-opus-4-6-v1",
-            "anthropic.claude-opus-4-6-v1",
             "anthropic.claude-opus-4-6-v1"
+          ],
+          "routeRegions": [
+            "ca-central-1",
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -5030,10 +5519,13 @@
           "description": "Routes requests to Anthropic Claude Opus 4.7 in ca-central-1, us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "anthropic.claude-opus-4-7",
-            "anthropic.claude-opus-4-7",
-            "anthropic.claude-opus-4-7",
             "anthropic.claude-opus-4-7"
+          ],
+          "routeRegions": [
+            "ca-central-1",
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -5042,10 +5534,13 @@
           "description": "Routes requests to Anthropic Claude Sonnet 4.5 in ca-central-1, us-east-1, us-east-2 and us-west-2.",
           "geo": "us",
           "models": [
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
             "anthropic.claude-sonnet-4-5-20250929-v1:0"
+          ],
+          "routeRegions": [
+            "ca-central-1",
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         },
         {
@@ -5054,10 +5549,13 @@
           "description": "Routes requests to Claude Sonnet 4.6 in us-east-1, us-east-2, ca-central-1, us-west-2.",
           "geo": "us",
           "models": [
-            "anthropic.claude-sonnet-4-6",
-            "anthropic.claude-sonnet-4-6",
-            "anthropic.claude-sonnet-4-6",
             "anthropic.claude-sonnet-4-6"
+          ],
+          "routeRegions": [
+            "ca-central-1",
+            "us-east-1",
+            "us-east-2",
+            "us-west-2"
           ]
         }
       ],
@@ -5067,81 +5565,81 @@
           "profileName": "GLOBAL Amazon Nova 2 Lite",
           "description": "Routes requests to Amazon Nova 2 Lite globally across all supported AWS Regions.",
           "models": [
-            "amazon.nova-2-lite-v1:0",
             "amazon.nova-2-lite-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
           "profileName": "Global Anthropic Claude Haiku 4.5",
           "description": "Routes requests to Anthropic Claude Haiku 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
             "anthropic.claude-haiku-4-5-20251001-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-5-20251101-v1:0",
           "profileName": "GLOBAL Anthropic Claude Opus 4.5",
           "description": "Routes requests to Anthropic Claude Opus 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-5-20251101-v1:0",
             "anthropic.claude-opus-4-5-20251101-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-6-v1",
           "profileName": "Global Anthropic Claude Opus 4.6",
           "description": "Routes requests to Anthropic Claude Opus 4.6 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-6-v1",
             "anthropic.claude-opus-4-6-v1"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-7",
           "profileName": "Global Anthropic Claude Opus 4.7",
           "description": "Routes requests to Anthropic Claude Opus 4.7 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-7",
             "anthropic.claude-opus-4-7"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
           "profileName": "Global Claude Sonnet 4.5",
           "description": "Routes requests to Claude Sonnet 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
             "anthropic.claude-sonnet-4-5-20250929-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-sonnet-4-6",
           "profileName": "Global Anthropic Claude Sonnet 4.6",
           "description": "Routes requests to Claude Sonnet 4.6 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-sonnet-4-6",
             "anthropic.claude-sonnet-4-6"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.cohere.embed-v4:0",
           "profileName": "Global Cohere Embed v4",
           "description": "Routes requests to Embed v4 globally across all supported AWS Regions.",
           "models": [
-            "cohere.embed-v4:0",
             "cohere.embed-v4:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.twelvelabs.pegasus-1-2-v1:0",
           "profileName": "GLOBAL TwelveLabs Pegasus v1.2",
           "description": "Routes requests to Pegasus v1.2 globally across all supported AWS Regions.",
           "models": [
-            "twelvelabs.pegasus-1-2-v1:0",
             "twelvelabs.pegasus-1-2-v1:0"
-          ]
+          ],
+          "routeRegions": []
         }
       ]
     },
@@ -5785,72 +6283,72 @@
           "profileName": "Global Anthropic Claude Haiku 4.5",
           "description": "Routes requests to Anthropic Claude Haiku 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
             "anthropic.claude-haiku-4-5-20251001-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-5-20251101-v1:0",
           "profileName": "GLOBAL Anthropic Claude Opus 4.5",
           "description": "Routes requests to Anthropic Claude Opus 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-5-20251101-v1:0",
             "anthropic.claude-opus-4-5-20251101-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-6-v1",
           "profileName": "Global Anthropic Claude Opus 4.6",
           "description": "Routes requests to Anthropic Claude Opus 4.6 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-6-v1",
             "anthropic.claude-opus-4-6-v1"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-7",
           "profileName": "Global Anthropic Claude Opus 4.7",
           "description": "Routes requests to Anthropic Claude Opus 4.7 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-7",
             "anthropic.claude-opus-4-7"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
           "profileName": "Global Claude Sonnet 4.5",
           "description": "Routes requests to Claude Sonnet 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
             "anthropic.claude-sonnet-4-5-20250929-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-sonnet-4-6",
           "profileName": "Global Anthropic Claude Sonnet 4.6",
           "description": "Routes requests to Claude Sonnet 4.6 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-sonnet-4-6",
             "anthropic.claude-sonnet-4-6"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.cohere.embed-v4:0",
           "profileName": "Global Cohere Embed v4",
           "description": "Routes requests to Embed v4 globally across all supported AWS Regions.",
           "models": [
-            "cohere.embed-v4:0",
             "cohere.embed-v4:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.twelvelabs.pegasus-1-2-v1:0",
           "profileName": "GLOBAL TwelveLabs Pegasus v1.2",
           "description": "Routes requests to Pegasus v1.2 globally across all supported AWS Regions.",
           "models": [
-            "twelvelabs.pegasus-1-2-v1:0",
             "twelvelabs.pegasus-1-2-v1:0"
-          ]
+          ],
+          "routeRegions": []
         }
       ]
     },
@@ -6469,12 +6967,15 @@
           "description": "Routes requests to Amazon Nova 2 Lite in eu-central-1, eu-north-1, eu-south-1, eu-south-2, eu-west-1 and eu-west-3.",
           "geo": "eu",
           "models": [
-            "amazon.nova-2-lite-v1:0",
-            "amazon.nova-2-lite-v1:0",
-            "amazon.nova-2-lite-v1:0",
-            "amazon.nova-2-lite-v1:0",
-            "amazon.nova-2-lite-v1:0",
             "amazon.nova-2-lite-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -6483,10 +6984,13 @@
           "description": "Routes requests to Nova Lite in eu-west-3, eu-west-1, eu-central-1 and eu-north-1.",
           "geo": "eu",
           "models": [
-            "amazon.nova-lite-v1:0",
-            "amazon.nova-lite-v1:0",
-            "amazon.nova-lite-v1:0",
             "amazon.nova-lite-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -6495,10 +6999,13 @@
           "description": "Routes requests to Nova Micro in eu-west-3, eu-west-1, eu-central-1 and eu-north-1.",
           "geo": "eu",
           "models": [
-            "amazon.nova-micro-v1:0",
-            "amazon.nova-micro-v1:0",
-            "amazon.nova-micro-v1:0",
             "amazon.nova-micro-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -6507,10 +7014,13 @@
           "description": "Routes requests to Nova Pro in eu-west-3, eu-west-1, eu-central-1 and eu-north-1.",
           "geo": "eu",
           "models": [
-            "amazon.nova-pro-v1:0",
-            "amazon.nova-pro-v1:0",
-            "amazon.nova-pro-v1:0",
             "amazon.nova-pro-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -6519,10 +7029,13 @@
           "description": "Routes requests to Anthropic Claude 3.7 Sonnet in eu-central-1, eu-north-1, eu-west-1 and eu-west-3.",
           "geo": "eu",
           "models": [
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
             "anthropic.claude-3-7-sonnet-20250219-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -6531,9 +7044,12 @@
           "description": "Routes requests to Anthropic Claude 3 Haiku in eu-central-1, eu-west-1 and eu-west-3.",
           "geo": "eu",
           "models": [
-            "anthropic.claude-3-haiku-20240307-v1:0",
-            "anthropic.claude-3-haiku-20240307-v1:0",
             "anthropic.claude-3-haiku-20240307-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -6542,9 +7058,12 @@
           "description": "Routes requests to Anthropic Claude 3 Sonnet in eu-central-1, eu-west-1 and eu-west-3.",
           "geo": "eu",
           "models": [
-            "anthropic.claude-3-sonnet-20240229-v1:0",
-            "anthropic.claude-3-sonnet-20240229-v1:0",
             "anthropic.claude-3-sonnet-20240229-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -6553,12 +7072,15 @@
           "description": "Routes requests to Anthropic Claude Haiku 4.5 in eu-north-1, eu-west-3, eu-south-1, eu-south-2, eu-west-1 and eu-central-1.",
           "geo": "eu",
           "models": [
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
             "anthropic.claude-haiku-4-5-20251001-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -6567,12 +7089,15 @@
           "description": "Routes requests to Claude Opus 4.5 in eu-north-1, eu-west-3, eu-south-1, eu-south-2, eu-west-1, eu-central-1.",
           "geo": "eu",
           "models": [
-            "anthropic.claude-opus-4-5-20251101-v1:0",
-            "anthropic.claude-opus-4-5-20251101-v1:0",
-            "anthropic.claude-opus-4-5-20251101-v1:0",
-            "anthropic.claude-opus-4-5-20251101-v1:0",
-            "anthropic.claude-opus-4-5-20251101-v1:0",
             "anthropic.claude-opus-4-5-20251101-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -6581,12 +7106,15 @@
           "description": "Routes requests to Claude Opus 4.6 in eu-north-1, eu-west-3, eu-south-1, eu-south-2, eu-west-1, eu-central-1.",
           "geo": "eu",
           "models": [
-            "anthropic.claude-opus-4-6-v1",
-            "anthropic.claude-opus-4-6-v1",
-            "anthropic.claude-opus-4-6-v1",
-            "anthropic.claude-opus-4-6-v1",
-            "anthropic.claude-opus-4-6-v1",
             "anthropic.claude-opus-4-6-v1"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -6595,12 +7123,15 @@
           "description": "Routes requests to Anthropic Claude Opus 4.7 in eu-central-1, eu-north-1, eu-south-1, eu-south-2, eu-west-1 and eu-west-3.",
           "geo": "eu",
           "models": [
-            "anthropic.claude-opus-4-7",
-            "anthropic.claude-opus-4-7",
-            "anthropic.claude-opus-4-7",
-            "anthropic.claude-opus-4-7",
-            "anthropic.claude-opus-4-7",
             "anthropic.claude-opus-4-7"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -6609,12 +7140,15 @@
           "description": "Routes requests to Claude Sonnet 4 in eu-central-1, eu-north-1, eu-south-1, eu-south-2, eu-west-1 and eu-west-3.",
           "geo": "eu",
           "models": [
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
             "anthropic.claude-sonnet-4-20250514-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -6623,12 +7157,15 @@
           "description": "Routes requests to Anthropic Claude Sonnet 4.5 in eu-north-1, eu-west-3, eu-south-1, eu-south-2, eu-west-1 and eu-central-1.",
           "geo": "eu",
           "models": [
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
             "anthropic.claude-sonnet-4-5-20250929-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -6637,12 +7174,15 @@
           "description": "Routes requests to Claude Sonnet 4.6 in eu-north-1, eu-west-3, eu-south-1, eu-south-2, eu-west-1, eu-central-1.",
           "geo": "eu",
           "models": [
-            "anthropic.claude-sonnet-4-6",
-            "anthropic.claude-sonnet-4-6",
-            "anthropic.claude-sonnet-4-6",
-            "anthropic.claude-sonnet-4-6",
-            "anthropic.claude-sonnet-4-6",
             "anthropic.claude-sonnet-4-6"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -6651,12 +7191,15 @@
           "description": "Routes requests to Embed v4 in eu-north-1, eu-west-3, eu-south-1, eu-south-2, eu-west-1, eu-central-1.",
           "geo": "eu",
           "models": [
-            "cohere.embed-v4:0",
-            "cohere.embed-v4:0",
-            "cohere.embed-v4:0",
-            "cohere.embed-v4:0",
-            "cohere.embed-v4:0",
             "cohere.embed-v4:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -6665,9 +7208,12 @@
           "description": "Routes requests to Meta Llama 3.2 1B Instruct in eu-central-1, eu-west-1 and eu-west-3.",
           "geo": "eu",
           "models": [
-            "meta.llama3-2-1b-instruct-v1:0",
-            "meta.llama3-2-1b-instruct-v1:0",
             "meta.llama3-2-1b-instruct-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -6676,9 +7222,12 @@
           "description": "Routes requests to Meta Llama 3.2 3B Instruct in eu-central-1, eu-west-1 and eu-west-3.",
           "geo": "eu",
           "models": [
-            "meta.llama3-2-3b-instruct-v1:0",
-            "meta.llama3-2-3b-instruct-v1:0",
             "meta.llama3-2-3b-instruct-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -6687,10 +7236,13 @@
           "description": "Routes requests to Mistral Pixtral Large 25.02 in eu-central-1, eu-north-1, eu-west-1 and eu-west-3.",
           "geo": "eu",
           "models": [
-            "mistral.pixtral-large-2502-v1:0",
-            "mistral.pixtral-large-2502-v1:0",
-            "mistral.pixtral-large-2502-v1:0",
             "mistral.pixtral-large-2502-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -6699,12 +7251,15 @@
           "description": "Routes requests to TwelveLabs Marengo Embed v2.7 in eu-west-1, eu-central-1, eu-south-1, eu-west-3, eu-south-2 and eu-north-1.",
           "geo": "eu",
           "models": [
-            "twelvelabs.marengo-embed-2-7-v1:0",
-            "twelvelabs.marengo-embed-2-7-v1:0",
-            "twelvelabs.marengo-embed-2-7-v1:0",
-            "twelvelabs.marengo-embed-2-7-v1:0",
-            "twelvelabs.marengo-embed-2-7-v1:0",
             "twelvelabs.marengo-embed-2-7-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -6713,12 +7268,15 @@
           "description": "Routes requests to Marengo Embed 3.0 in eu-north-1, eu-west-3, eu-south-1, eu-south-2, eu-west-1, eu-central-1.",
           "geo": "eu",
           "models": [
-            "twelvelabs.marengo-embed-3-0-v1:0",
-            "twelvelabs.marengo-embed-3-0-v1:0",
-            "twelvelabs.marengo-embed-3-0-v1:0",
-            "twelvelabs.marengo-embed-3-0-v1:0",
-            "twelvelabs.marengo-embed-3-0-v1:0",
             "twelvelabs.marengo-embed-3-0-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -6727,12 +7285,15 @@
           "description": "Routes requests to TwelveLabs Pegasus v1.2 in eu-central-1, eu-north-1, eu-south-1, eu-south-2, eu-west-1 and eu-west-3.",
           "geo": "eu",
           "models": [
-            "twelvelabs.pegasus-1-2-v1:0",
-            "twelvelabs.pegasus-1-2-v1:0",
-            "twelvelabs.pegasus-1-2-v1:0",
-            "twelvelabs.pegasus-1-2-v1:0",
-            "twelvelabs.pegasus-1-2-v1:0",
             "twelvelabs.pegasus-1-2-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-3"
           ]
         }
       ],
@@ -6742,90 +7303,90 @@
           "profileName": "GLOBAL Amazon Nova 2 Lite",
           "description": "Routes requests to Amazon Nova 2 Lite globally across all supported AWS Regions.",
           "models": [
-            "amazon.nova-2-lite-v1:0",
             "amazon.nova-2-lite-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
           "profileName": "Global Anthropic Claude Haiku 4.5",
           "description": "Routes requests to Anthropic Claude Haiku 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
             "anthropic.claude-haiku-4-5-20251001-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-5-20251101-v1:0",
           "profileName": "GLOBAL Anthropic Claude Opus 4.5",
           "description": "Routes requests to Anthropic Claude Opus 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-5-20251101-v1:0",
             "anthropic.claude-opus-4-5-20251101-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-6-v1",
           "profileName": "Global Anthropic Claude Opus 4.6",
           "description": "Routes requests to Anthropic Claude Opus 4.6 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-6-v1",
             "anthropic.claude-opus-4-6-v1"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-7",
           "profileName": "Global Anthropic Claude Opus 4.7",
           "description": "Routes requests to Anthropic Claude Opus 4.7 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-7",
             "anthropic.claude-opus-4-7"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-sonnet-4-20250514-v1:0",
           "profileName": "Global Claude Sonnet 4",
           "description": "Routes requests to Claude Sonnet 4 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-sonnet-4-20250514-v1:0",
             "anthropic.claude-sonnet-4-20250514-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
           "profileName": "Global Claude Sonnet 4.5",
           "description": "Routes requests to Claude Sonnet 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
             "anthropic.claude-sonnet-4-5-20250929-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-sonnet-4-6",
           "profileName": "Global Anthropic Claude Sonnet 4.6",
           "description": "Routes requests to Anthropic Claude Sonnet 4.6 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-sonnet-4-6",
             "anthropic.claude-sonnet-4-6"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.cohere.embed-v4:0",
           "profileName": "Global Cohere Embed v4",
           "description": "Routes requests to Embed v4 globally across all supported AWS Regions.",
           "models": [
-            "cohere.embed-v4:0",
             "cohere.embed-v4:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.twelvelabs.pegasus-1-2-v1:0",
           "profileName": "Global TwelveLabs Pegasus v1.2",
           "description": "Routes requests to Pegasus v1.2 globally across all supported AWS Regions.",
           "models": [
-            "twelvelabs.pegasus-1-2-v1:0",
             "twelvelabs.pegasus-1-2-v1:0"
-          ]
+          ],
+          "routeRegions": []
         }
       ]
     },
@@ -7627,13 +8188,16 @@
           "description": "Routes requests to Claude Haiku 4.5 in eu-north-1, eu-west-3, eu-south-1, eu-west-2, eu-south-2, eu-west-1, eu-central-1.",
           "geo": "eu",
           "models": [
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
             "anthropic.claude-haiku-4-5-20251001-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-2",
+            "eu-west-3"
           ]
         },
         {
@@ -7642,13 +8206,16 @@
           "description": "Routes requests to Claude Opus 4.5 in eu-north-1, eu-west-3, eu-south-1, eu-west-2, eu-south-2, eu-west-1, eu-central-1.",
           "geo": "eu",
           "models": [
-            "anthropic.claude-opus-4-5-20251101-v1:0",
-            "anthropic.claude-opus-4-5-20251101-v1:0",
-            "anthropic.claude-opus-4-5-20251101-v1:0",
-            "anthropic.claude-opus-4-5-20251101-v1:0",
-            "anthropic.claude-opus-4-5-20251101-v1:0",
-            "anthropic.claude-opus-4-5-20251101-v1:0",
             "anthropic.claude-opus-4-5-20251101-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-2",
+            "eu-west-3"
           ]
         },
         {
@@ -7657,13 +8224,16 @@
           "description": "Routes requests to Claude Opus 4.6 in eu-north-1, eu-west-3, eu-south-1, eu-west-2, eu-south-2, eu-west-1, eu-central-1.",
           "geo": "eu",
           "models": [
-            "anthropic.claude-opus-4-6-v1",
-            "anthropic.claude-opus-4-6-v1",
-            "anthropic.claude-opus-4-6-v1",
-            "anthropic.claude-opus-4-6-v1",
-            "anthropic.claude-opus-4-6-v1",
-            "anthropic.claude-opus-4-6-v1",
             "anthropic.claude-opus-4-6-v1"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-2",
+            "eu-west-3"
           ]
         },
         {
@@ -7672,13 +8242,16 @@
           "description": "Routes requests to Anthropic Claude Opus 4.7 in eu-central-1, eu-north-1, eu-south-1, eu-south-2, eu-west-1, eu-west-2 and eu-west-3.",
           "geo": "eu",
           "models": [
-            "anthropic.claude-opus-4-7",
-            "anthropic.claude-opus-4-7",
-            "anthropic.claude-opus-4-7",
-            "anthropic.claude-opus-4-7",
-            "anthropic.claude-opus-4-7",
-            "anthropic.claude-opus-4-7",
             "anthropic.claude-opus-4-7"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-2",
+            "eu-west-3"
           ]
         },
         {
@@ -7687,13 +8260,16 @@
           "description": "Routes requests to Anthropic Claude Sonnet 4.5 in eu-north-1, eu-west-3, eu-south-1, eu-south-2, eu-west-1, eu-central-1 and eu-west-2.",
           "geo": "eu",
           "models": [
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
             "anthropic.claude-sonnet-4-5-20250929-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-2",
+            "eu-west-3"
           ]
         },
         {
@@ -7702,13 +8278,16 @@
           "description": "Routes requests to Claude Sonnet 4.6 in eu-north-1, eu-west-3, eu-south-1, eu-west-2, eu-south-2, eu-west-1, eu-central-1.",
           "geo": "eu",
           "models": [
-            "anthropic.claude-sonnet-4-6",
-            "anthropic.claude-sonnet-4-6",
-            "anthropic.claude-sonnet-4-6",
-            "anthropic.claude-sonnet-4-6",
-            "anthropic.claude-sonnet-4-6",
-            "anthropic.claude-sonnet-4-6",
             "anthropic.claude-sonnet-4-6"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-2",
+            "eu-west-3"
           ]
         },
         {
@@ -7717,13 +8296,16 @@
           "description": "Routes requests to Embed v4 in eu-north-1, eu-west-3, eu-south-1, eu-west-2, eu-south-2, eu-west-1, eu-central-1.",
           "geo": "eu",
           "models": [
-            "cohere.embed-v4:0",
-            "cohere.embed-v4:0",
-            "cohere.embed-v4:0",
-            "cohere.embed-v4:0",
-            "cohere.embed-v4:0",
-            "cohere.embed-v4:0",
             "cohere.embed-v4:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-2",
+            "eu-west-3"
           ]
         },
         {
@@ -7732,13 +8314,16 @@
           "description": "Routes requests to Pegasus v1.2 in eu-north-1, eu-west-3, eu-south-1, eu-west-2, eu-south-2, eu-west-1, eu-central-1.",
           "geo": "eu",
           "models": [
-            "twelvelabs.pegasus-1-2-v1:0",
-            "twelvelabs.pegasus-1-2-v1:0",
-            "twelvelabs.pegasus-1-2-v1:0",
-            "twelvelabs.pegasus-1-2-v1:0",
-            "twelvelabs.pegasus-1-2-v1:0",
-            "twelvelabs.pegasus-1-2-v1:0",
             "twelvelabs.pegasus-1-2-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-2",
+            "eu-west-3"
           ]
         }
       ],
@@ -7748,81 +8333,81 @@
           "profileName": "GLOBAL Amazon Nova 2 Lite",
           "description": "Routes requests to Amazon Nova 2 Lite globally across all supported AWS Regions.",
           "models": [
-            "amazon.nova-2-lite-v1:0",
             "amazon.nova-2-lite-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
           "profileName": "Global Anthropic Claude Haiku 4.5",
           "description": "Routes requests to Anthropic Claude Haiku 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
             "anthropic.claude-haiku-4-5-20251001-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-5-20251101-v1:0",
           "profileName": "GLOBAL Anthropic Claude Opus 4.5",
           "description": "Routes requests to Anthropic Claude Opus 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-5-20251101-v1:0",
             "anthropic.claude-opus-4-5-20251101-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-6-v1",
           "profileName": "Global Anthropic Claude Opus 4.6",
           "description": "Routes requests to Anthropic Claude Opus 4.6 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-6-v1",
             "anthropic.claude-opus-4-6-v1"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-7",
           "profileName": "Global Anthropic Claude Opus 4.7",
           "description": "Routes requests to Anthropic Claude Opus 4.7 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-7",
             "anthropic.claude-opus-4-7"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
           "profileName": "Global Claude Sonnet 4.5",
           "description": "Routes requests to Claude Sonnet 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
             "anthropic.claude-sonnet-4-5-20250929-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-sonnet-4-6",
           "profileName": "Global Anthropic Claude Sonnet 4.6",
           "description": "Routes requests to Anthropic Claude Sonnet 4.6 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-sonnet-4-6",
             "anthropic.claude-sonnet-4-6"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.cohere.embed-v4:0",
           "profileName": "Global Cohere Embed v4",
           "description": "Routes requests to Embed v4 globally across all supported AWS Regions.",
           "models": [
-            "cohere.embed-v4:0",
             "cohere.embed-v4:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.twelvelabs.pegasus-1-2-v1:0",
           "profileName": "GLOBAL TwelveLabs Pegasus v1.2",
           "description": "Routes requests to Pegasus v1.2 globally across all supported AWS Regions.",
           "models": [
-            "twelvelabs.pegasus-1-2-v1:0",
             "twelvelabs.pegasus-1-2-v1:0"
-          ]
+          ],
+          "routeRegions": []
         }
       ]
     },
@@ -7973,12 +8558,15 @@
           "description": "Routes requests to Amazon Nova 2 Lite in eu-central-1, eu-north-1, eu-south-1, eu-south-2, eu-west-1 and eu-west-3.",
           "geo": "eu",
           "models": [
-            "amazon.nova-2-lite-v1:0",
-            "amazon.nova-2-lite-v1:0",
-            "amazon.nova-2-lite-v1:0",
-            "amazon.nova-2-lite-v1:0",
-            "amazon.nova-2-lite-v1:0",
             "amazon.nova-2-lite-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -7987,10 +8575,13 @@
           "description": "Routes requests to Nova Lite in eu-west-3, eu-west-1, eu-central-1 and eu-north-1.",
           "geo": "eu",
           "models": [
-            "amazon.nova-lite-v1:0",
-            "amazon.nova-lite-v1:0",
-            "amazon.nova-lite-v1:0",
             "amazon.nova-lite-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -7999,10 +8590,13 @@
           "description": "Routes requests to Nova Micro in eu-west-3, eu-west-1, eu-central-1 and eu-north-1.",
           "geo": "eu",
           "models": [
-            "amazon.nova-micro-v1:0",
-            "amazon.nova-micro-v1:0",
-            "amazon.nova-micro-v1:0",
             "amazon.nova-micro-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -8011,10 +8605,13 @@
           "description": "Routes requests to Nova Pro in eu-west-3, eu-west-1, eu-central-1 and eu-north-1.",
           "geo": "eu",
           "models": [
-            "amazon.nova-pro-v1:0",
-            "amazon.nova-pro-v1:0",
-            "amazon.nova-pro-v1:0",
             "amazon.nova-pro-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -8023,10 +8620,13 @@
           "description": "Routes requests to Anthropic Claude 3.7 Sonnet in eu-central-1, eu-north-1, eu-west-1 and eu-west-3.",
           "geo": "eu",
           "models": [
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
             "anthropic.claude-3-7-sonnet-20250219-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -8035,9 +8635,12 @@
           "description": "Routes requests to Anthropic Claude 3 Haiku in eu-central-1, eu-west-1 and eu-west-3.",
           "geo": "eu",
           "models": [
-            "anthropic.claude-3-haiku-20240307-v1:0",
-            "anthropic.claude-3-haiku-20240307-v1:0",
             "anthropic.claude-3-haiku-20240307-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -8046,9 +8649,12 @@
           "description": "Routes requests to Anthropic Claude 3 Sonnet in eu-central-1, eu-west-1 and eu-west-3.",
           "geo": "eu",
           "models": [
-            "anthropic.claude-3-sonnet-20240229-v1:0",
-            "anthropic.claude-3-sonnet-20240229-v1:0",
             "anthropic.claude-3-sonnet-20240229-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -8057,12 +8663,15 @@
           "description": "Routes requests to Anthropic Claude Haiku 4.5 in eu-north-1, eu-west-3, eu-south-1, eu-south-2, eu-west-1 and eu-central-1.",
           "geo": "eu",
           "models": [
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
             "anthropic.claude-haiku-4-5-20251001-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -8071,12 +8680,15 @@
           "description": "Routes requests to Claude Opus 4.5 in eu-north-1, eu-west-3, eu-south-1, eu-south-2, eu-west-1, eu-central-1.",
           "geo": "eu",
           "models": [
-            "anthropic.claude-opus-4-5-20251101-v1:0",
-            "anthropic.claude-opus-4-5-20251101-v1:0",
-            "anthropic.claude-opus-4-5-20251101-v1:0",
-            "anthropic.claude-opus-4-5-20251101-v1:0",
-            "anthropic.claude-opus-4-5-20251101-v1:0",
             "anthropic.claude-opus-4-5-20251101-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -8085,12 +8697,15 @@
           "description": "Routes requests to Claude Opus 4.6 in eu-north-1, eu-west-3, eu-south-1, eu-south-2, eu-west-1, eu-central-1.",
           "geo": "eu",
           "models": [
-            "anthropic.claude-opus-4-6-v1",
-            "anthropic.claude-opus-4-6-v1",
-            "anthropic.claude-opus-4-6-v1",
-            "anthropic.claude-opus-4-6-v1",
-            "anthropic.claude-opus-4-6-v1",
             "anthropic.claude-opus-4-6-v1"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -8099,12 +8714,15 @@
           "description": "Routes requests to Anthropic Claude Opus 4.7 in eu-central-1, eu-north-1, eu-south-1, eu-south-2, eu-west-1 and eu-west-3.",
           "geo": "eu",
           "models": [
-            "anthropic.claude-opus-4-7",
-            "anthropic.claude-opus-4-7",
-            "anthropic.claude-opus-4-7",
-            "anthropic.claude-opus-4-7",
-            "anthropic.claude-opus-4-7",
             "anthropic.claude-opus-4-7"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -8113,12 +8731,15 @@
           "description": "Routes requests to Claude Sonnet 4 in eu-central-1, eu-north-1, eu-south-1, eu-south-2, eu-west-1 and eu-west-3.",
           "geo": "eu",
           "models": [
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
             "anthropic.claude-sonnet-4-20250514-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -8127,12 +8748,15 @@
           "description": "Routes requests to Anthropic Claude Sonnet 4.5 in eu-north-1, eu-west-3, eu-south-1, eu-south-2, eu-west-1 and eu-central-1.",
           "geo": "eu",
           "models": [
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
             "anthropic.claude-sonnet-4-5-20250929-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -8141,12 +8765,15 @@
           "description": "Routes requests to Claude Sonnet 4.6 in eu-north-1, eu-west-3, eu-south-1, eu-south-2, eu-west-1, eu-central-1.",
           "geo": "eu",
           "models": [
-            "anthropic.claude-sonnet-4-6",
-            "anthropic.claude-sonnet-4-6",
-            "anthropic.claude-sonnet-4-6",
-            "anthropic.claude-sonnet-4-6",
-            "anthropic.claude-sonnet-4-6",
             "anthropic.claude-sonnet-4-6"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -8155,12 +8782,15 @@
           "description": "Routes requests to Embed v4 in eu-north-1, eu-west-3, eu-south-1, eu-south-2, eu-west-1, eu-central-1.",
           "geo": "eu",
           "models": [
-            "cohere.embed-v4:0",
-            "cohere.embed-v4:0",
-            "cohere.embed-v4:0",
-            "cohere.embed-v4:0",
-            "cohere.embed-v4:0",
             "cohere.embed-v4:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -8169,9 +8799,12 @@
           "description": "Routes requests to Meta Llama 3.2 1B Instruct in eu-central-1, eu-west-1 and eu-west-3.",
           "geo": "eu",
           "models": [
-            "meta.llama3-2-1b-instruct-v1:0",
-            "meta.llama3-2-1b-instruct-v1:0",
             "meta.llama3-2-1b-instruct-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -8180,9 +8813,12 @@
           "description": "Routes requests to Meta Llama 3.2 3B Instruct in eu-central-1, eu-west-1 and eu-west-3.",
           "geo": "eu",
           "models": [
-            "meta.llama3-2-3b-instruct-v1:0",
-            "meta.llama3-2-3b-instruct-v1:0",
             "meta.llama3-2-3b-instruct-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -8191,10 +8827,13 @@
           "description": "Routes requests to Mistral Pixtral Large 25.02 in eu-central-1, eu-north-1, eu-west-1 and eu-west-3.",
           "geo": "eu",
           "models": [
-            "mistral.pixtral-large-2502-v1:0",
-            "mistral.pixtral-large-2502-v1:0",
-            "mistral.pixtral-large-2502-v1:0",
             "mistral.pixtral-large-2502-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -8203,12 +8842,15 @@
           "description": "Routes requests to Pegasus v1.2 in eu-north-1, eu-west-3, eu-south-1, eu-south-2, eu-west-1, eu-central-1.",
           "geo": "eu",
           "models": [
-            "twelvelabs.pegasus-1-2-v1:0",
-            "twelvelabs.pegasus-1-2-v1:0",
-            "twelvelabs.pegasus-1-2-v1:0",
-            "twelvelabs.pegasus-1-2-v1:0",
-            "twelvelabs.pegasus-1-2-v1:0",
             "twelvelabs.pegasus-1-2-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-3"
           ]
         }
       ],
@@ -8218,81 +8860,81 @@
           "profileName": "GLOBAL Amazon Nova 2 Lite",
           "description": "Routes requests to Amazon Nova 2 Lite globally across all supported AWS Regions.",
           "models": [
-            "amazon.nova-2-lite-v1:0",
             "amazon.nova-2-lite-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
           "profileName": "Global Anthropic Claude Haiku 4.5",
           "description": "Routes requests to Anthropic Claude Haiku 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
             "anthropic.claude-haiku-4-5-20251001-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-5-20251101-v1:0",
           "profileName": "GLOBAL Anthropic Claude Opus 4.5",
           "description": "Routes requests to Anthropic Claude Opus 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-5-20251101-v1:0",
             "anthropic.claude-opus-4-5-20251101-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-6-v1",
           "profileName": "Global Anthropic Claude Opus 4.6",
           "description": "Routes requests to Anthropic Claude Opus 4.6 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-6-v1",
             "anthropic.claude-opus-4-6-v1"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-7",
           "profileName": "Global Anthropic Claude Opus 4.7",
           "description": "Routes requests to Anthropic Claude Opus 4.7 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-7",
             "anthropic.claude-opus-4-7"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
           "profileName": "Global Claude Sonnet 4.5",
           "description": "Routes requests to Claude Sonnet 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
             "anthropic.claude-sonnet-4-5-20250929-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-sonnet-4-6",
           "profileName": "Global Anthropic Claude Sonnet 4.6",
           "description": "Routes requests to Claude Sonnet 4.6 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-sonnet-4-6",
             "anthropic.claude-sonnet-4-6"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.cohere.embed-v4:0",
           "profileName": "Global Cohere Embed v4",
           "description": "Routes requests to Embed v4 globally across all supported AWS Regions.",
           "models": [
-            "cohere.embed-v4:0",
             "cohere.embed-v4:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.twelvelabs.pegasus-1-2-v1:0",
           "profileName": "GLOBAL TwelveLabs Pegasus v1.2",
           "description": "Routes requests to Pegasus v1.2 globally across all supported AWS Regions.",
           "models": [
-            "twelvelabs.pegasus-1-2-v1:0",
             "twelvelabs.pegasus-1-2-v1:0"
-          ]
+          ],
+          "routeRegions": []
         }
       ]
     },
@@ -8578,12 +9220,15 @@
           "description": "Routes requests to Amazon Nova 2 Lite in eu-central-1, eu-north-1, eu-south-1, eu-south-2, eu-west-1 and eu-west-3.",
           "geo": "eu",
           "models": [
-            "amazon.nova-2-lite-v1:0",
-            "amazon.nova-2-lite-v1:0",
-            "amazon.nova-2-lite-v1:0",
-            "amazon.nova-2-lite-v1:0",
-            "amazon.nova-2-lite-v1:0",
             "amazon.nova-2-lite-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -8592,10 +9237,13 @@
           "description": "Routes requests to Nova Lite in eu-west-3, eu-west-1, eu-central-1 and eu-north-1.",
           "geo": "eu",
           "models": [
-            "amazon.nova-lite-v1:0",
-            "amazon.nova-lite-v1:0",
-            "amazon.nova-lite-v1:0",
             "amazon.nova-lite-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -8604,10 +9252,13 @@
           "description": "Routes requests to Nova Micro in eu-west-3, eu-west-1, eu-central-1 and eu-north-1.",
           "geo": "eu",
           "models": [
-            "amazon.nova-micro-v1:0",
-            "amazon.nova-micro-v1:0",
-            "amazon.nova-micro-v1:0",
             "amazon.nova-micro-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -8616,10 +9267,13 @@
           "description": "Routes requests to Nova Pro in eu-west-3, eu-west-1, eu-central-1 and eu-north-1.",
           "geo": "eu",
           "models": [
-            "amazon.nova-pro-v1:0",
-            "amazon.nova-pro-v1:0",
-            "amazon.nova-pro-v1:0",
             "amazon.nova-pro-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -8628,10 +9282,13 @@
           "description": "Routes requests to Anthropic Claude 3.7 Sonnet in eu-central-1, eu-north-1, eu-west-1 and eu-west-3.",
           "geo": "eu",
           "models": [
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
             "anthropic.claude-3-7-sonnet-20250219-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -8640,9 +9297,12 @@
           "description": "Routes requests to Anthropic Claude 3 Haiku in eu-central-1, eu-west-1 and eu-west-3.",
           "geo": "eu",
           "models": [
-            "anthropic.claude-3-haiku-20240307-v1:0",
-            "anthropic.claude-3-haiku-20240307-v1:0",
             "anthropic.claude-3-haiku-20240307-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -8651,9 +9311,12 @@
           "description": "Routes requests to Anthropic Claude 3 Sonnet in eu-central-1, eu-west-1 and eu-west-3.",
           "geo": "eu",
           "models": [
-            "anthropic.claude-3-sonnet-20240229-v1:0",
-            "anthropic.claude-3-sonnet-20240229-v1:0",
             "anthropic.claude-3-sonnet-20240229-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -8662,12 +9325,15 @@
           "description": "Routes requests to Anthropic Claude Haiku 4.5 in eu-north-1, eu-west-3, eu-south-1, eu-south-2, eu-west-1 and eu-central-1.",
           "geo": "eu",
           "models": [
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
             "anthropic.claude-haiku-4-5-20251001-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -8676,12 +9342,15 @@
           "description": "Routes requests to Claude Opus 4.5 in eu-north-1, eu-west-3, eu-south-1, eu-south-2, eu-west-1, eu-central-1.",
           "geo": "eu",
           "models": [
-            "anthropic.claude-opus-4-5-20251101-v1:0",
-            "anthropic.claude-opus-4-5-20251101-v1:0",
-            "anthropic.claude-opus-4-5-20251101-v1:0",
-            "anthropic.claude-opus-4-5-20251101-v1:0",
-            "anthropic.claude-opus-4-5-20251101-v1:0",
             "anthropic.claude-opus-4-5-20251101-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -8690,12 +9359,15 @@
           "description": "Routes requests to Claude Opus 4.6 in eu-north-1, eu-west-3, eu-south-1, eu-south-2, eu-west-1, eu-central-1.",
           "geo": "eu",
           "models": [
-            "anthropic.claude-opus-4-6-v1",
-            "anthropic.claude-opus-4-6-v1",
-            "anthropic.claude-opus-4-6-v1",
-            "anthropic.claude-opus-4-6-v1",
-            "anthropic.claude-opus-4-6-v1",
             "anthropic.claude-opus-4-6-v1"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -8704,12 +9376,15 @@
           "description": "Routes requests to Anthropic Claude Opus 4.7 in eu-central-1, eu-north-1, eu-south-1, eu-south-2, eu-west-1 and eu-west-3.",
           "geo": "eu",
           "models": [
-            "anthropic.claude-opus-4-7",
-            "anthropic.claude-opus-4-7",
-            "anthropic.claude-opus-4-7",
-            "anthropic.claude-opus-4-7",
-            "anthropic.claude-opus-4-7",
             "anthropic.claude-opus-4-7"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -8718,12 +9393,15 @@
           "description": "Routes requests to Claude Sonnet 4 in eu-central-1, eu-north-1, eu-south-1, eu-south-2, eu-west-1 and eu-west-3.",
           "geo": "eu",
           "models": [
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
             "anthropic.claude-sonnet-4-20250514-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -8732,12 +9410,15 @@
           "description": "Routes requests to Anthropic Claude Sonnet 4.5 in eu-north-1, eu-west-3, eu-south-1, eu-south-2, eu-west-1 and eu-central-1.",
           "geo": "eu",
           "models": [
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
             "anthropic.claude-sonnet-4-5-20250929-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -8746,12 +9427,15 @@
           "description": "Routes requests to Claude Sonnet 4.6 in eu-north-1, eu-west-3, eu-south-1, eu-south-2, eu-west-1, eu-central-1.",
           "geo": "eu",
           "models": [
-            "anthropic.claude-sonnet-4-6",
-            "anthropic.claude-sonnet-4-6",
-            "anthropic.claude-sonnet-4-6",
-            "anthropic.claude-sonnet-4-6",
-            "anthropic.claude-sonnet-4-6",
             "anthropic.claude-sonnet-4-6"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -8760,12 +9444,15 @@
           "description": "Routes requests to Embed v4 in eu-north-1, eu-west-3, eu-south-1, eu-south-2, eu-west-1, eu-central-1.",
           "geo": "eu",
           "models": [
-            "cohere.embed-v4:0",
-            "cohere.embed-v4:0",
-            "cohere.embed-v4:0",
-            "cohere.embed-v4:0",
-            "cohere.embed-v4:0",
             "cohere.embed-v4:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -8774,9 +9461,12 @@
           "description": "Routes requests to Meta Llama 3.2 1B Instruct in eu-central-1, eu-west-1 and eu-west-3.",
           "geo": "eu",
           "models": [
-            "meta.llama3-2-1b-instruct-v1:0",
-            "meta.llama3-2-1b-instruct-v1:0",
             "meta.llama3-2-1b-instruct-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -8785,9 +9475,12 @@
           "description": "Routes requests to Meta Llama 3.2 3B Instruct in eu-central-1, eu-west-1 and eu-west-3.",
           "geo": "eu",
           "models": [
-            "meta.llama3-2-3b-instruct-v1:0",
-            "meta.llama3-2-3b-instruct-v1:0",
             "meta.llama3-2-3b-instruct-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -8796,10 +9489,13 @@
           "description": "Routes requests to Mistral Pixtral Large 25.02 in eu-central-1, eu-north-1, eu-west-1 and eu-west-3.",
           "geo": "eu",
           "models": [
-            "mistral.pixtral-large-2502-v1:0",
-            "mistral.pixtral-large-2502-v1:0",
-            "mistral.pixtral-large-2502-v1:0",
             "mistral.pixtral-large-2502-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -8808,12 +9504,15 @@
           "description": "Routes requests to Pegasus v1.2 in eu-north-1, eu-west-3, eu-south-1, eu-south-2, eu-west-1, eu-central-1.",
           "geo": "eu",
           "models": [
-            "twelvelabs.pegasus-1-2-v1:0",
-            "twelvelabs.pegasus-1-2-v1:0",
-            "twelvelabs.pegasus-1-2-v1:0",
-            "twelvelabs.pegasus-1-2-v1:0",
-            "twelvelabs.pegasus-1-2-v1:0",
             "twelvelabs.pegasus-1-2-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-3"
           ]
         }
       ],
@@ -8823,81 +9522,81 @@
           "profileName": "GLOBAL Amazon Nova 2 Lite",
           "description": "Routes requests to Amazon Nova 2 Lite globally across all supported AWS Regions.",
           "models": [
-            "amazon.nova-2-lite-v1:0",
             "amazon.nova-2-lite-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
           "profileName": "Global Anthropic Claude Haiku 4.5",
           "description": "Routes requests to Anthropic Claude Haiku 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
             "anthropic.claude-haiku-4-5-20251001-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-5-20251101-v1:0",
           "profileName": "GLOBAL Anthropic Claude Opus 4.5",
           "description": "Routes requests to Anthropic Claude Opus 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-5-20251101-v1:0",
             "anthropic.claude-opus-4-5-20251101-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-6-v1",
           "profileName": "Global Anthropic Claude Opus 4.6",
           "description": "Routes requests to Claude Opus 4.6 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-6-v1",
             "anthropic.claude-opus-4-6-v1"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-7",
           "profileName": "Global Anthropic Claude Opus 4.7",
           "description": "Routes requests to Anthropic Claude Opus 4.7 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-7",
             "anthropic.claude-opus-4-7"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
           "profileName": "Global Claude Sonnet 4.5",
           "description": "Routes requests to Claude Sonnet 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
             "anthropic.claude-sonnet-4-5-20250929-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-sonnet-4-6",
           "profileName": "Global Anthropic Claude Sonnet 4.6",
           "description": "Routes requests to Claude Sonnet 4.6 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-sonnet-4-6",
             "anthropic.claude-sonnet-4-6"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.cohere.embed-v4:0",
           "profileName": "Global Cohere Embed v4",
           "description": "Routes requests to Embed v4 globally across all supported AWS Regions.",
           "models": [
-            "cohere.embed-v4:0",
             "cohere.embed-v4:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.twelvelabs.pegasus-1-2-v1:0",
           "profileName": "GLOBAL TwelveLabs Pegasus v1.2",
           "description": "Routes requests to Pegasus v1.2 globally across all supported AWS Regions.",
           "models": [
-            "twelvelabs.pegasus-1-2-v1:0",
             "twelvelabs.pegasus-1-2-v1:0"
-          ]
+          ],
+          "routeRegions": []
         }
       ]
     },
@@ -9217,12 +9916,15 @@
           "description": "Routes requests to Amazon Nova 2 Lite in eu-central-1, eu-north-1, eu-south-1, eu-south-2, eu-west-1 and eu-west-3.",
           "geo": "eu",
           "models": [
-            "amazon.nova-2-lite-v1:0",
-            "amazon.nova-2-lite-v1:0",
-            "amazon.nova-2-lite-v1:0",
-            "amazon.nova-2-lite-v1:0",
-            "amazon.nova-2-lite-v1:0",
             "amazon.nova-2-lite-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -9231,10 +9933,13 @@
           "description": "Routes requests to Nova Lite in eu-central-1, eu-north-1, eu-west-1 and eu-west-3.",
           "geo": "eu",
           "models": [
-            "amazon.nova-lite-v1:0",
-            "amazon.nova-lite-v1:0",
-            "amazon.nova-lite-v1:0",
             "amazon.nova-lite-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -9243,10 +9948,13 @@
           "description": "Routes requests to Nova Micro in eu-central-1, eu-north-1, eu-west-1 and eu-west-3.",
           "geo": "eu",
           "models": [
-            "amazon.nova-micro-v1:0",
-            "amazon.nova-micro-v1:0",
-            "amazon.nova-micro-v1:0",
             "amazon.nova-micro-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -9255,10 +9963,13 @@
           "description": "Routes requests to Nova Pro in eu-central-1, eu-north-1, eu-west-1 and eu-west-3.",
           "geo": "eu",
           "models": [
-            "amazon.nova-pro-v1:0",
-            "amazon.nova-pro-v1:0",
-            "amazon.nova-pro-v1:0",
             "amazon.nova-pro-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -9267,10 +9978,13 @@
           "description": "Routes requests to Anthropic Claude 3.7 Sonnet in eu-central-1, eu-north-1, eu-west-1 and eu-west-3.",
           "geo": "eu",
           "models": [
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
             "anthropic.claude-3-7-sonnet-20250219-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -9279,12 +9993,15 @@
           "description": "Routes requests to Anthropic Claude Haiku 4.5 in eu-north-1, eu-west-3, eu-south-1, eu-south-2, eu-west-1 and eu-central-1.",
           "geo": "eu",
           "models": [
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
             "anthropic.claude-haiku-4-5-20251001-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -9293,12 +10010,15 @@
           "description": "Routes requests to Claude Opus 4.5 in eu-north-1, eu-west-3, eu-south-1, eu-south-2, eu-west-1, eu-central-1.",
           "geo": "eu",
           "models": [
-            "anthropic.claude-opus-4-5-20251101-v1:0",
-            "anthropic.claude-opus-4-5-20251101-v1:0",
-            "anthropic.claude-opus-4-5-20251101-v1:0",
-            "anthropic.claude-opus-4-5-20251101-v1:0",
-            "anthropic.claude-opus-4-5-20251101-v1:0",
             "anthropic.claude-opus-4-5-20251101-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -9307,12 +10027,15 @@
           "description": "Routes requests to Claude Opus 4.6 in eu-north-1, eu-west-3, eu-south-1, eu-south-2, eu-west-1, eu-central-1.",
           "geo": "eu",
           "models": [
-            "anthropic.claude-opus-4-6-v1",
-            "anthropic.claude-opus-4-6-v1",
-            "anthropic.claude-opus-4-6-v1",
-            "anthropic.claude-opus-4-6-v1",
-            "anthropic.claude-opus-4-6-v1",
             "anthropic.claude-opus-4-6-v1"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -9321,12 +10044,15 @@
           "description": "Routes requests to Anthropic Claude Opus 4.7 in eu-central-1, eu-north-1, eu-south-1, eu-south-2, eu-west-1 and eu-west-3.",
           "geo": "eu",
           "models": [
-            "anthropic.claude-opus-4-7",
-            "anthropic.claude-opus-4-7",
-            "anthropic.claude-opus-4-7",
-            "anthropic.claude-opus-4-7",
-            "anthropic.claude-opus-4-7",
             "anthropic.claude-opus-4-7"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -9335,12 +10061,15 @@
           "description": "Routes requests to Claude Sonnet 4 in eu-central-1, eu-north-1, eu-south-1, eu-south-2, eu-west-1 and eu-west-3.",
           "geo": "eu",
           "models": [
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
             "anthropic.claude-sonnet-4-20250514-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -9349,12 +10078,15 @@
           "description": "Routes requests to Anthropic Claude Sonnet 4.5 in eu-north-1, eu-west-3, eu-south-1, eu-south-2, eu-west-1 and eu-central-1.",
           "geo": "eu",
           "models": [
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
             "anthropic.claude-sonnet-4-5-20250929-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -9363,12 +10095,15 @@
           "description": "Routes requests to Claude Sonnet 4.6 in eu-north-1, eu-west-3, eu-south-1, eu-south-2, eu-west-1, eu-central-1.",
           "geo": "eu",
           "models": [
-            "anthropic.claude-sonnet-4-6",
-            "anthropic.claude-sonnet-4-6",
-            "anthropic.claude-sonnet-4-6",
-            "anthropic.claude-sonnet-4-6",
-            "anthropic.claude-sonnet-4-6",
             "anthropic.claude-sonnet-4-6"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -9377,12 +10112,15 @@
           "description": "Routes requests to Embed v4 in eu-north-1, eu-west-3, eu-south-1, eu-south-2, eu-west-1, eu-central-1.",
           "geo": "eu",
           "models": [
-            "cohere.embed-v4:0",
-            "cohere.embed-v4:0",
-            "cohere.embed-v4:0",
-            "cohere.embed-v4:0",
-            "cohere.embed-v4:0",
             "cohere.embed-v4:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -9391,10 +10129,13 @@
           "description": "Routes requests to Mistral Pixtral Large 25.02 in eu-central-1, eu-north-1, eu-west-1 and eu-west-3.",
           "geo": "eu",
           "models": [
-            "mistral.pixtral-large-2502-v1:0",
-            "mistral.pixtral-large-2502-v1:0",
-            "mistral.pixtral-large-2502-v1:0",
             "mistral.pixtral-large-2502-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-west-1",
+            "eu-west-3"
           ]
         },
         {
@@ -9403,12 +10144,15 @@
           "description": "Routes requests to Pegasus v1.2 in eu-north-1, eu-west-3, eu-south-1, eu-south-2, eu-west-1, eu-central-1.",
           "geo": "eu",
           "models": [
-            "twelvelabs.pegasus-1-2-v1:0",
-            "twelvelabs.pegasus-1-2-v1:0",
-            "twelvelabs.pegasus-1-2-v1:0",
-            "twelvelabs.pegasus-1-2-v1:0",
-            "twelvelabs.pegasus-1-2-v1:0",
             "twelvelabs.pegasus-1-2-v1:0"
+          ],
+          "routeRegions": [
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-3"
           ]
         }
       ],
@@ -9418,81 +10162,81 @@
           "profileName": "GLOBAL Amazon Nova 2 Lite",
           "description": "Routes requests to Amazon Nova 2 Lite globally across all supported AWS Regions.",
           "models": [
-            "amazon.nova-2-lite-v1:0",
             "amazon.nova-2-lite-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
           "profileName": "Global Anthropic Claude Haiku 4.5",
           "description": "Routes requests to Anthropic Claude Haiku 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
             "anthropic.claude-haiku-4-5-20251001-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-5-20251101-v1:0",
           "profileName": "GLOBAL Anthropic Claude Opus 4.5",
           "description": "Routes requests to Anthropic Claude Opus 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-5-20251101-v1:0",
             "anthropic.claude-opus-4-5-20251101-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-6-v1",
           "profileName": "Global Anthropic Claude Opus 4.6",
           "description": "Routes requests to Anthropic Claude Opus 4.6 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-6-v1",
             "anthropic.claude-opus-4-6-v1"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-7",
           "profileName": "Global Anthropic Claude Opus 4.7",
           "description": "Routes requests to Anthropic Claude Opus 4.7 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-7",
             "anthropic.claude-opus-4-7"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
           "profileName": "Global Claude Sonnet 4.5",
           "description": "Routes requests to Claude Sonnet 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
             "anthropic.claude-sonnet-4-5-20250929-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-sonnet-4-6",
           "profileName": "Global Anthropic Claude Sonnet 4.6",
           "description": "Routes requests to Claude Sonnet 4.6 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-sonnet-4-6",
             "anthropic.claude-sonnet-4-6"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.cohere.embed-v4:0",
           "profileName": "Global Cohere Embed v4",
           "description": "Routes requests to Embed v4 globally across all supported AWS Regions.",
           "models": [
-            "cohere.embed-v4:0",
             "cohere.embed-v4:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.twelvelabs.pegasus-1-2-v1:0",
           "profileName": "GLOBAL TwelveLabs Pegasus v1.2",
           "description": "Routes requests to Pegasus v1.2 globally across all supported AWS Regions.",
           "models": [
-            "twelvelabs.pegasus-1-2-v1:0",
             "twelvelabs.pegasus-1-2-v1:0"
-          ]
+          ],
+          "routeRegions": []
         }
       ]
     },
@@ -10265,12 +11009,15 @@
           "description": "Routes requests to Nova Lite in ap-southeast-2, ap-northeast-1, ap-south-1, ap-northeast-2, ap-southeast-1 and ap-northeast-3.",
           "geo": "apac",
           "models": [
-            "amazon.nova-lite-v1:0",
-            "amazon.nova-lite-v1:0",
-            "amazon.nova-lite-v1:0",
-            "amazon.nova-lite-v1:0",
-            "amazon.nova-lite-v1:0",
             "amazon.nova-lite-v1:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-northeast-3",
+            "ap-south-1",
+            "ap-southeast-1",
+            "ap-southeast-2"
           ]
         },
         {
@@ -10279,12 +11026,15 @@
           "description": "Routes requests to Nova Micro in ap-southeast-2, ap-northeast-1, ap-south-1, ap-northeast-2, ap-southeast-1 and ap-northeast-3.",
           "geo": "apac",
           "models": [
-            "amazon.nova-micro-v1:0",
-            "amazon.nova-micro-v1:0",
-            "amazon.nova-micro-v1:0",
-            "amazon.nova-micro-v1:0",
-            "amazon.nova-micro-v1:0",
             "amazon.nova-micro-v1:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-northeast-3",
+            "ap-south-1",
+            "ap-southeast-1",
+            "ap-southeast-2"
           ]
         },
         {
@@ -10293,12 +11043,15 @@
           "description": "Routes requests to Nova Pro in ap-southeast-2, ap-northeast-1, ap-south-1, ap-northeast-2, ap-southeast-1 and ap-northeast-3.",
           "geo": "apac",
           "models": [
-            "amazon.nova-pro-v1:0",
-            "amazon.nova-pro-v1:0",
-            "amazon.nova-pro-v1:0",
-            "amazon.nova-pro-v1:0",
-            "amazon.nova-pro-v1:0",
             "amazon.nova-pro-v1:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-northeast-3",
+            "ap-south-1",
+            "ap-southeast-1",
+            "ap-southeast-2"
           ]
         },
         {
@@ -10307,11 +11060,14 @@
           "description": "Routes requests to Anthropic Claude 3.5 Sonnet in ap-northeast-1, ap-northeast-2, ap-southeast-1, ap-southeast-2 and ap-south-1.",
           "geo": "apac",
           "models": [
-            "anthropic.claude-3-5-sonnet-20240620-v1:0",
-            "anthropic.claude-3-5-sonnet-20240620-v1:0",
-            "anthropic.claude-3-5-sonnet-20240620-v1:0",
-            "anthropic.claude-3-5-sonnet-20240620-v1:0",
             "anthropic.claude-3-5-sonnet-20240620-v1:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-south-1",
+            "ap-southeast-1",
+            "ap-southeast-2"
           ]
         },
         {
@@ -10320,12 +11076,15 @@
           "description": "Routes requests to Anthropic Claude 3.5 Sonnet v2 in ap-northeast-1, ap-northeast-2, ap-northeast-3, ap-south-1, ap-southeast-1 and ap-southeast-2.",
           "geo": "apac",
           "models": [
-            "anthropic.claude-3-5-sonnet-20241022-v2:0",
-            "anthropic.claude-3-5-sonnet-20241022-v2:0",
-            "anthropic.claude-3-5-sonnet-20241022-v2:0",
-            "anthropic.claude-3-5-sonnet-20241022-v2:0",
-            "anthropic.claude-3-5-sonnet-20241022-v2:0",
             "anthropic.claude-3-5-sonnet-20241022-v2:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-northeast-3",
+            "ap-south-1",
+            "ap-southeast-1",
+            "ap-southeast-2"
           ]
         },
         {
@@ -10334,13 +11093,16 @@
           "description": "Routes requests to Anthropic Claude 3.7 Sonnet in ap-northeast-1, ap-northeast-2, ap-northeast-3, ap-south-1, ap-south-2, ap-southeast-1 and ap-southeast-2.",
           "geo": "apac",
           "models": [
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
             "anthropic.claude-3-7-sonnet-20250219-v1:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-northeast-3",
+            "ap-south-1",
+            "ap-south-2",
+            "ap-southeast-1",
+            "ap-southeast-2"
           ]
         },
         {
@@ -10349,11 +11111,14 @@
           "description": "Routes requests to Anthropic Claude 3 Haiku in ap-northeast-1, ap-northeast-2, ap-southeast-2, ap-south-1 and ap-southeast-1.",
           "geo": "apac",
           "models": [
-            "anthropic.claude-3-haiku-20240307-v1:0",
-            "anthropic.claude-3-haiku-20240307-v1:0",
-            "anthropic.claude-3-haiku-20240307-v1:0",
-            "anthropic.claude-3-haiku-20240307-v1:0",
             "anthropic.claude-3-haiku-20240307-v1:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-south-1",
+            "ap-southeast-1",
+            "ap-southeast-2"
           ]
         },
         {
@@ -10362,11 +11127,14 @@
           "description": "Routes requests to Anthropic Claude 3 Sonnet in ap-northeast-1, ap-northeast-2, ap-southeast-1, ap-southeast-2 and ap-south-1.",
           "geo": "apac",
           "models": [
-            "anthropic.claude-3-sonnet-20240229-v1:0",
-            "anthropic.claude-3-sonnet-20240229-v1:0",
-            "anthropic.claude-3-sonnet-20240229-v1:0",
-            "anthropic.claude-3-sonnet-20240229-v1:0",
             "anthropic.claude-3-sonnet-20240229-v1:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-south-1",
+            "ap-southeast-1",
+            "ap-southeast-2"
           ]
         },
         {
@@ -10375,14 +11143,17 @@
           "description": "Routes requests to Claude Sonnet 4 in ap-northeast-1, ap-northeast-2, ap-northeast-3, ap-south-1, ap-south-2, ap-southeast-1, ap-southeast-2 and ap-southeast-4.",
           "geo": "apac",
           "models": [
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
             "anthropic.claude-sonnet-4-20250514-v1:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-northeast-3",
+            "ap-south-1",
+            "ap-south-2",
+            "ap-southeast-1",
+            "ap-southeast-2",
+            "ap-southeast-4"
           ]
         },
         {
@@ -10391,8 +11162,11 @@
           "description": "Routes requests to Amazon Nova 2 Lite in ap-northeast-1 and ap-northeast-3.",
           "geo": "jp",
           "models": [
-            "amazon.nova-2-lite-v1:0",
             "amazon.nova-2-lite-v1:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-3"
           ]
         },
         {
@@ -10401,8 +11175,11 @@
           "description": "Routes requests to Claude Haiku 4.5 in ap-northeast-3, ap-northeast-1.",
           "geo": "jp",
           "models": [
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
             "anthropic.claude-haiku-4-5-20251001-v1:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-3"
           ]
         },
         {
@@ -10411,8 +11188,11 @@
           "description": "Routes requests to Claude Opus 4.7 in ap-northeast-3, ap-northeast-1.",
           "geo": "jp",
           "models": [
-            "anthropic.claude-opus-4-7",
             "anthropic.claude-opus-4-7"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-3"
           ]
         },
         {
@@ -10421,8 +11201,11 @@
           "description": "Routes requests to Claude Sonnet 4.5 in ap-northeast-3, ap-northeast-1.",
           "geo": "jp",
           "models": [
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
             "anthropic.claude-sonnet-4-5-20250929-v1:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-3"
           ]
         },
         {
@@ -10431,8 +11214,11 @@
           "description": "Routes requests to Claude Sonnet 4.6 in ap-northeast-3, ap-northeast-1.",
           "geo": "jp",
           "models": [
-            "anthropic.claude-sonnet-4-6",
             "anthropic.claude-sonnet-4-6"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-3"
           ]
         }
       ],
@@ -10442,90 +11228,90 @@
           "profileName": "GLOBAL Amazon Nova 2 Lite",
           "description": "Routes requests to Amazon Nova 2 Lite globally across all supported AWS Regions.",
           "models": [
-            "amazon.nova-2-lite-v1:0",
             "amazon.nova-2-lite-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
           "profileName": "Global Anthropic Claude Haiku 4.5",
           "description": "Routes requests to Anthropic Claude Haiku 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
             "anthropic.claude-haiku-4-5-20251001-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-5-20251101-v1:0",
           "profileName": "GLOBAL Anthropic Claude Opus 4.5",
           "description": "Routes requests to Anthropic Claude Opus 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-5-20251101-v1:0",
             "anthropic.claude-opus-4-5-20251101-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-6-v1",
           "profileName": "Global Anthropic Claude Opus 4.6",
           "description": "Routes requests to Anthropic Claude Opus 4.6 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-6-v1",
             "anthropic.claude-opus-4-6-v1"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-7",
           "profileName": "Global Anthropic Claude Opus 4.7",
           "description": "Routes requests to Anthropic Claude Opus 4.7 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-7",
             "anthropic.claude-opus-4-7"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-sonnet-4-20250514-v1:0",
           "profileName": "Global Claude Sonnet 4",
           "description": "Routes requests to Claude Sonnet 4 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-sonnet-4-20250514-v1:0",
             "anthropic.claude-sonnet-4-20250514-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
           "profileName": "Global Claude Sonnet 4.5",
           "description": "Routes requests to Claude Sonnet 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
             "anthropic.claude-sonnet-4-5-20250929-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-sonnet-4-6",
           "profileName": "Global Anthropic Claude Sonnet 4.6",
           "description": "Routes requests to Claude Sonnet 4.6 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-sonnet-4-6",
             "anthropic.claude-sonnet-4-6"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.cohere.embed-v4:0",
           "profileName": "Global Cohere Embed v4",
           "description": "Routes requests to Embed v4 globally across all supported AWS Regions.",
           "models": [
-            "cohere.embed-v4:0",
             "cohere.embed-v4:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.twelvelabs.pegasus-1-2-v1:0",
           "profileName": "GLOBAL TwelveLabs Pegasus v1.2",
           "description": "Routes requests to Pegasus v1.2 globally across all supported AWS Regions.",
           "models": [
-            "twelvelabs.pegasus-1-2-v1:0",
             "twelvelabs.pegasus-1-2-v1:0"
-          ]
+          ],
+          "routeRegions": []
         }
       ]
     },
@@ -10639,12 +11425,15 @@
           "description": "Routes requests to Nova Lite in ap-southeast-2, ap-northeast-1, ap-south-1, ap-northeast-2, ap-southeast-1 and ap-northeast-3.",
           "geo": "apac",
           "models": [
-            "amazon.nova-lite-v1:0",
-            "amazon.nova-lite-v1:0",
-            "amazon.nova-lite-v1:0",
-            "amazon.nova-lite-v1:0",
-            "amazon.nova-lite-v1:0",
             "amazon.nova-lite-v1:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-northeast-3",
+            "ap-south-1",
+            "ap-southeast-1",
+            "ap-southeast-2"
           ]
         },
         {
@@ -10653,12 +11442,15 @@
           "description": "Routes requests to Nova Micro in ap-southeast-2, ap-northeast-1, ap-south-1, ap-northeast-2, ap-southeast-1 and ap-northeast-3.",
           "geo": "apac",
           "models": [
-            "amazon.nova-micro-v1:0",
-            "amazon.nova-micro-v1:0",
-            "amazon.nova-micro-v1:0",
-            "amazon.nova-micro-v1:0",
-            "amazon.nova-micro-v1:0",
             "amazon.nova-micro-v1:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-northeast-3",
+            "ap-south-1",
+            "ap-southeast-1",
+            "ap-southeast-2"
           ]
         },
         {
@@ -10667,12 +11459,15 @@
           "description": "Routes requests to Nova Pro in ap-southeast-2, ap-northeast-1, ap-south-1, ap-northeast-2, ap-southeast-1 and ap-northeast-3.",
           "geo": "apac",
           "models": [
-            "amazon.nova-pro-v1:0",
-            "amazon.nova-pro-v1:0",
-            "amazon.nova-pro-v1:0",
-            "amazon.nova-pro-v1:0",
-            "amazon.nova-pro-v1:0",
             "amazon.nova-pro-v1:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-northeast-3",
+            "ap-south-1",
+            "ap-southeast-1",
+            "ap-southeast-2"
           ]
         },
         {
@@ -10681,11 +11476,14 @@
           "description": "Routes requests to Anthropic Claude 3.5 Sonnet in ap-northeast-1, ap-northeast-2, ap-southeast-1, ap-southeast-2 and ap-south-1.",
           "geo": "apac",
           "models": [
-            "anthropic.claude-3-5-sonnet-20240620-v1:0",
-            "anthropic.claude-3-5-sonnet-20240620-v1:0",
-            "anthropic.claude-3-5-sonnet-20240620-v1:0",
-            "anthropic.claude-3-5-sonnet-20240620-v1:0",
             "anthropic.claude-3-5-sonnet-20240620-v1:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-south-1",
+            "ap-southeast-1",
+            "ap-southeast-2"
           ]
         },
         {
@@ -10694,12 +11492,15 @@
           "description": "Routes requests to Anthropic Claude 3.5 Sonnet v2 in ap-northeast-1, ap-northeast-2, ap-northeast-3, ap-south-1, ap-southeast-1 and ap-southeast-2.",
           "geo": "apac",
           "models": [
-            "anthropic.claude-3-5-sonnet-20241022-v2:0",
-            "anthropic.claude-3-5-sonnet-20241022-v2:0",
-            "anthropic.claude-3-5-sonnet-20241022-v2:0",
-            "anthropic.claude-3-5-sonnet-20241022-v2:0",
-            "anthropic.claude-3-5-sonnet-20241022-v2:0",
             "anthropic.claude-3-5-sonnet-20241022-v2:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-northeast-3",
+            "ap-south-1",
+            "ap-southeast-1",
+            "ap-southeast-2"
           ]
         },
         {
@@ -10708,13 +11509,16 @@
           "description": "Routes requests to Anthropic Claude 3.7 Sonnet in ap-northeast-1, ap-northeast-2, ap-northeast-3, ap-south-1, ap-south-2, ap-southeast-1 and ap-southeast-2.",
           "geo": "apac",
           "models": [
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
             "anthropic.claude-3-7-sonnet-20250219-v1:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-northeast-3",
+            "ap-south-1",
+            "ap-south-2",
+            "ap-southeast-1",
+            "ap-southeast-2"
           ]
         },
         {
@@ -10723,11 +11527,14 @@
           "description": "Routes requests to Anthropic Claude 3 Haiku in ap-northeast-1, ap-northeast-2, ap-southeast-2, ap-south-1 and ap-southeast-1.",
           "geo": "apac",
           "models": [
-            "anthropic.claude-3-haiku-20240307-v1:0",
-            "anthropic.claude-3-haiku-20240307-v1:0",
-            "anthropic.claude-3-haiku-20240307-v1:0",
-            "anthropic.claude-3-haiku-20240307-v1:0",
             "anthropic.claude-3-haiku-20240307-v1:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-south-1",
+            "ap-southeast-1",
+            "ap-southeast-2"
           ]
         },
         {
@@ -10736,11 +11543,14 @@
           "description": "Routes requests to Anthropic Claude 3 Sonnet in ap-northeast-1, ap-northeast-2, ap-southeast-1, ap-southeast-2 and ap-south-1.",
           "geo": "apac",
           "models": [
-            "anthropic.claude-3-sonnet-20240229-v1:0",
-            "anthropic.claude-3-sonnet-20240229-v1:0",
-            "anthropic.claude-3-sonnet-20240229-v1:0",
-            "anthropic.claude-3-sonnet-20240229-v1:0",
             "anthropic.claude-3-sonnet-20240229-v1:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-south-1",
+            "ap-southeast-1",
+            "ap-southeast-2"
           ]
         },
         {
@@ -10749,14 +11559,17 @@
           "description": "Routes requests to Claude Sonnet 4 in ap-northeast-1, ap-northeast-2, ap-northeast-3, ap-south-1, ap-south-2, ap-southeast-1, ap-southeast-2 and ap-southeast-4.",
           "geo": "apac",
           "models": [
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
             "anthropic.claude-sonnet-4-20250514-v1:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-northeast-3",
+            "ap-south-1",
+            "ap-south-2",
+            "ap-southeast-1",
+            "ap-southeast-2",
+            "ap-southeast-4"
           ]
         },
         {
@@ -10765,15 +11578,18 @@
           "description": "Routes requests to TwelveLabs Marengo Embed v2.7 in ap-northeast-2, ap-northeast-1, ap-northeast-3, ap-southeast-2, ap-southeast-4, ap-south-2, ap-south-1, ap-southeast-1 and ap-southeast-3.",
           "geo": "apac",
           "models": [
-            "twelvelabs.marengo-embed-2-7-v1:0",
-            "twelvelabs.marengo-embed-2-7-v1:0",
-            "twelvelabs.marengo-embed-2-7-v1:0",
-            "twelvelabs.marengo-embed-2-7-v1:0",
-            "twelvelabs.marengo-embed-2-7-v1:0",
-            "twelvelabs.marengo-embed-2-7-v1:0",
-            "twelvelabs.marengo-embed-2-7-v1:0",
-            "twelvelabs.marengo-embed-2-7-v1:0",
             "twelvelabs.marengo-embed-2-7-v1:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-northeast-3",
+            "ap-south-1",
+            "ap-south-2",
+            "ap-southeast-1",
+            "ap-southeast-2",
+            "ap-southeast-3",
+            "ap-southeast-4"
           ]
         },
         {
@@ -10782,14 +11598,17 @@
           "description": "Routes requests to Pegasus v1.2 in ap-south-2, ap-south-1, ap-southeast-1, ap-northeast-3, ap-southeast-2, ap-northeast-2, ap-northeast-1, ap-southeast-4.",
           "geo": "apac",
           "models": [
-            "twelvelabs.pegasus-1-2-v1:0",
-            "twelvelabs.pegasus-1-2-v1:0",
-            "twelvelabs.pegasus-1-2-v1:0",
-            "twelvelabs.pegasus-1-2-v1:0",
-            "twelvelabs.pegasus-1-2-v1:0",
-            "twelvelabs.pegasus-1-2-v1:0",
-            "twelvelabs.pegasus-1-2-v1:0",
             "twelvelabs.pegasus-1-2-v1:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-northeast-3",
+            "ap-south-1",
+            "ap-south-2",
+            "ap-southeast-1",
+            "ap-southeast-2",
+            "ap-southeast-4"
           ]
         }
       ],
@@ -10799,81 +11618,81 @@
           "profileName": "GLOBAL Amazon Nova 2 Lite",
           "description": "Routes requests to Amazon Nova 2 Lite globally across all supported AWS Regions.",
           "models": [
-            "amazon.nova-2-lite-v1:0",
             "amazon.nova-2-lite-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
           "profileName": "Global Anthropic Claude Haiku 4.5",
           "description": "Routes requests to Anthropic Claude Haiku 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
             "anthropic.claude-haiku-4-5-20251001-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-5-20251101-v1:0",
           "profileName": "GLOBAL Anthropic Claude Opus 4.5",
           "description": "Routes requests to Anthropic Claude Opus 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-5-20251101-v1:0",
             "anthropic.claude-opus-4-5-20251101-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-6-v1",
           "profileName": "Global Anthropic Claude Opus 4.6",
           "description": "Routes requests to Anthropic Claude Opus 4.6 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-6-v1",
             "anthropic.claude-opus-4-6-v1"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-7",
           "profileName": "Global Anthropic Claude Opus 4.7",
           "description": "Routes requests to Anthropic Claude Opus 4.7 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-7",
             "anthropic.claude-opus-4-7"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
           "profileName": "Global Claude Sonnet 4.5",
           "description": "Routes requests to Claude Sonnet 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
             "anthropic.claude-sonnet-4-5-20250929-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-sonnet-4-6",
           "profileName": "Global Anthropic Claude Sonnet 4.6",
           "description": "Routes requests to Anthropic Claude Sonnet 4.6 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-sonnet-4-6",
             "anthropic.claude-sonnet-4-6"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.cohere.embed-v4:0",
           "profileName": "Global Cohere Embed v4",
           "description": "Routes requests to Embed v4 globally across all supported AWS Regions.",
           "models": [
-            "cohere.embed-v4:0",
             "cohere.embed-v4:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.twelvelabs.pegasus-1-2-v1:0",
           "profileName": "GLOBAL TwelveLabs Pegasus v1.2",
           "description": "Routes requests to Pegasus v1.2 globally across all supported AWS Regions.",
           "models": [
-            "twelvelabs.pegasus-1-2-v1:0",
             "twelvelabs.pegasus-1-2-v1:0"
-          ]
+          ],
+          "routeRegions": []
         }
       ]
     },
@@ -10902,12 +11721,15 @@
           "description": "Routes requests to Anthropic Claude 3.5 Sonnet v2 in ap-southeast-2, ap-southeast-1, ap-northeast-2, ap-northeast-1, ap-south-1 and ap-northeast-3.",
           "geo": "apac",
           "models": [
-            "anthropic.claude-3-5-sonnet-20241022-v2:0",
-            "anthropic.claude-3-5-sonnet-20241022-v2:0",
-            "anthropic.claude-3-5-sonnet-20241022-v2:0",
-            "anthropic.claude-3-5-sonnet-20241022-v2:0",
-            "anthropic.claude-3-5-sonnet-20241022-v2:0",
             "anthropic.claude-3-5-sonnet-20241022-v2:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-northeast-3",
+            "ap-south-1",
+            "ap-southeast-1",
+            "ap-southeast-2"
           ]
         },
         {
@@ -10916,13 +11738,16 @@
           "description": "Routes requests to Anthropic Claude 3.7 Sonnet in ap-northeast-1, ap-northeast-2, ap-northeast-3, ap-south-1, ap-south-2, ap-southeast-1 and ap-southeast-2.",
           "geo": "apac",
           "models": [
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
             "anthropic.claude-3-7-sonnet-20250219-v1:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-northeast-3",
+            "ap-south-1",
+            "ap-south-2",
+            "ap-southeast-1",
+            "ap-southeast-2"
           ]
         },
         {
@@ -10931,14 +11756,17 @@
           "description": "Routes requests to Claude Sonnet 4 in ap-northeast-1, ap-northeast-2, ap-northeast-3, ap-south-1, ap-south-2, ap-southeast-1, ap-southeast-2 and ap-southeast-4.",
           "geo": "apac",
           "models": [
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
             "anthropic.claude-sonnet-4-20250514-v1:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-northeast-3",
+            "ap-south-1",
+            "ap-south-2",
+            "ap-southeast-1",
+            "ap-southeast-2",
+            "ap-southeast-4"
           ]
         },
         {
@@ -10947,8 +11775,11 @@
           "description": "Routes requests to Claude Haiku 4.5 in ap-northeast-3, ap-northeast-1.",
           "geo": "jp",
           "models": [
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
             "anthropic.claude-haiku-4-5-20251001-v1:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-3"
           ]
         },
         {
@@ -10957,8 +11788,11 @@
           "description": "Routes requests to Claude Opus 4.7 in ap-northeast-3, ap-northeast-1.",
           "geo": "jp",
           "models": [
-            "anthropic.claude-opus-4-7",
             "anthropic.claude-opus-4-7"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-3"
           ]
         },
         {
@@ -10967,8 +11801,11 @@
           "description": "Routes requests to Claude Sonnet 4.5 in ap-northeast-3, ap-northeast-1.",
           "geo": "jp",
           "models": [
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
             "anthropic.claude-sonnet-4-5-20250929-v1:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-3"
           ]
         },
         {
@@ -10977,8 +11814,11 @@
           "description": "Routes requests to Claude Sonnet 4.6 in ap-northeast-3, ap-northeast-1.",
           "geo": "jp",
           "models": [
-            "anthropic.claude-sonnet-4-6",
             "anthropic.claude-sonnet-4-6"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-3"
           ]
         }
       ],
@@ -10988,72 +11828,72 @@
           "profileName": "Global Anthropic Claude Haiku 4.5",
           "description": "Routes requests to Anthropic Claude Haiku 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
             "anthropic.claude-haiku-4-5-20251001-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-5-20251101-v1:0",
           "profileName": "GLOBAL Anthropic Claude Opus 4.5",
           "description": "Routes requests to Anthropic Claude Opus 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-5-20251101-v1:0",
             "anthropic.claude-opus-4-5-20251101-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-6-v1",
           "profileName": "Global Anthropic Claude Opus 4.6",
           "description": "Routes requests to Anthropic Claude Opus 4.6 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-6-v1",
             "anthropic.claude-opus-4-6-v1"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-7",
           "profileName": "Global Anthropic Claude Opus 4.7",
           "description": "Routes requests to Anthropic Claude Opus 4.7 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-7",
             "anthropic.claude-opus-4-7"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
           "profileName": "Global Claude Sonnet 4.5",
           "description": "Routes requests to Claude Sonnet 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
             "anthropic.claude-sonnet-4-5-20250929-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-sonnet-4-6",
           "profileName": "Global Anthropic Claude Sonnet 4.6",
           "description": "Routes requests to Claude Sonnet 4.6 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-sonnet-4-6",
             "anthropic.claude-sonnet-4-6"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.cohere.embed-v4:0",
           "profileName": "Global Cohere Embed v4",
           "description": "Routes requests to Embed v4 globally across all supported AWS Regions.",
           "models": [
-            "cohere.embed-v4:0",
             "cohere.embed-v4:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.twelvelabs.pegasus-1-2-v1:0",
           "profileName": "GLOBAL TwelveLabs Pegasus v1.2",
           "description": "Routes requests to Pegasus v1.2 globally across all supported AWS Regions.",
           "models": [
-            "twelvelabs.pegasus-1-2-v1:0",
             "twelvelabs.pegasus-1-2-v1:0"
-          ]
+          ],
+          "routeRegions": []
         }
       ]
     },
@@ -11772,12 +12612,15 @@
           "description": "Routes requests to Nova Lite in ap-southeast-2, ap-northeast-1, ap-south-1, ap-northeast-2, ap-southeast-1 and ap-northeast-3.",
           "geo": "apac",
           "models": [
-            "amazon.nova-lite-v1:0",
-            "amazon.nova-lite-v1:0",
-            "amazon.nova-lite-v1:0",
-            "amazon.nova-lite-v1:0",
-            "amazon.nova-lite-v1:0",
             "amazon.nova-lite-v1:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-northeast-3",
+            "ap-south-1",
+            "ap-southeast-1",
+            "ap-southeast-2"
           ]
         },
         {
@@ -11786,12 +12629,15 @@
           "description": "Routes requests to Nova Micro in ap-southeast-2, ap-northeast-1, ap-south-1, ap-northeast-2, ap-southeast-1 and ap-northeast-3.",
           "geo": "apac",
           "models": [
-            "amazon.nova-micro-v1:0",
-            "amazon.nova-micro-v1:0",
-            "amazon.nova-micro-v1:0",
-            "amazon.nova-micro-v1:0",
-            "amazon.nova-micro-v1:0",
             "amazon.nova-micro-v1:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-northeast-3",
+            "ap-south-1",
+            "ap-southeast-1",
+            "ap-southeast-2"
           ]
         },
         {
@@ -11800,12 +12646,15 @@
           "description": "Routes requests to Nova Pro in ap-southeast-2, ap-northeast-1, ap-south-1, ap-northeast-2, ap-southeast-1 and ap-northeast-3.",
           "geo": "apac",
           "models": [
-            "amazon.nova-pro-v1:0",
-            "amazon.nova-pro-v1:0",
-            "amazon.nova-pro-v1:0",
-            "amazon.nova-pro-v1:0",
-            "amazon.nova-pro-v1:0",
             "amazon.nova-pro-v1:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-northeast-3",
+            "ap-south-1",
+            "ap-southeast-1",
+            "ap-southeast-2"
           ]
         },
         {
@@ -11814,11 +12663,14 @@
           "description": "Routes requests to Anthropic Claude 3.5 Sonnet in ap-northeast-1, ap-northeast-2, ap-southeast-1, ap-southeast-2 and ap-south-1.",
           "geo": "apac",
           "models": [
-            "anthropic.claude-3-5-sonnet-20240620-v1:0",
-            "anthropic.claude-3-5-sonnet-20240620-v1:0",
-            "anthropic.claude-3-5-sonnet-20240620-v1:0",
-            "anthropic.claude-3-5-sonnet-20240620-v1:0",
             "anthropic.claude-3-5-sonnet-20240620-v1:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-south-1",
+            "ap-southeast-1",
+            "ap-southeast-2"
           ]
         },
         {
@@ -11827,12 +12679,15 @@
           "description": "Routes requests to Anthropic Claude 3.5 Sonnet v2 in ap-northeast-1, ap-northeast-2, ap-northeast-3, ap-south-1, ap-southeast-1 and ap-southeast-2.",
           "geo": "apac",
           "models": [
-            "anthropic.claude-3-5-sonnet-20241022-v2:0",
-            "anthropic.claude-3-5-sonnet-20241022-v2:0",
-            "anthropic.claude-3-5-sonnet-20241022-v2:0",
-            "anthropic.claude-3-5-sonnet-20241022-v2:0",
-            "anthropic.claude-3-5-sonnet-20241022-v2:0",
             "anthropic.claude-3-5-sonnet-20241022-v2:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-northeast-3",
+            "ap-south-1",
+            "ap-southeast-1",
+            "ap-southeast-2"
           ]
         },
         {
@@ -11841,13 +12696,16 @@
           "description": "Routes requests to Anthropic Claude 3.7 Sonnet in ap-northeast-1, ap-northeast-2, ap-northeast-3, ap-south-1, ap-south-2, ap-southeast-1 and ap-southeast-2.",
           "geo": "apac",
           "models": [
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
             "anthropic.claude-3-7-sonnet-20250219-v1:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-northeast-3",
+            "ap-south-1",
+            "ap-south-2",
+            "ap-southeast-1",
+            "ap-southeast-2"
           ]
         },
         {
@@ -11856,11 +12714,14 @@
           "description": "Routes requests to Anthropic Claude 3 Haiku in ap-northeast-1, ap-northeast-2, ap-southeast-2, ap-south-1 and ap-southeast-1.",
           "geo": "apac",
           "models": [
-            "anthropic.claude-3-haiku-20240307-v1:0",
-            "anthropic.claude-3-haiku-20240307-v1:0",
-            "anthropic.claude-3-haiku-20240307-v1:0",
-            "anthropic.claude-3-haiku-20240307-v1:0",
             "anthropic.claude-3-haiku-20240307-v1:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-south-1",
+            "ap-southeast-1",
+            "ap-southeast-2"
           ]
         },
         {
@@ -11869,11 +12730,14 @@
           "description": "Routes requests to Anthropic Claude 3 Sonnet in ap-northeast-1, ap-northeast-2, ap-southeast-1, ap-southeast-2 and ap-south-1.",
           "geo": "apac",
           "models": [
-            "anthropic.claude-3-sonnet-20240229-v1:0",
-            "anthropic.claude-3-sonnet-20240229-v1:0",
-            "anthropic.claude-3-sonnet-20240229-v1:0",
-            "anthropic.claude-3-sonnet-20240229-v1:0",
             "anthropic.claude-3-sonnet-20240229-v1:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-south-1",
+            "ap-southeast-1",
+            "ap-southeast-2"
           ]
         },
         {
@@ -11882,14 +12746,17 @@
           "description": "Routes requests to Claude Sonnet 4 in ap-northeast-1, ap-northeast-2, ap-northeast-3, ap-south-1, ap-south-2, ap-southeast-1, ap-southeast-2 and ap-southeast-4.",
           "geo": "apac",
           "models": [
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
             "anthropic.claude-sonnet-4-20250514-v1:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-northeast-3",
+            "ap-south-1",
+            "ap-south-2",
+            "ap-southeast-1",
+            "ap-southeast-2",
+            "ap-southeast-4"
           ]
         }
       ],
@@ -11899,81 +12766,81 @@
           "profileName": "GLOBAL Amazon Nova 2 Lite",
           "description": "Routes requests to Amazon Nova 2 Lite globally across all supported AWS Regions.",
           "models": [
-            "amazon.nova-2-lite-v1:0",
             "amazon.nova-2-lite-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
           "profileName": "Global Anthropic Claude Haiku 4.5",
           "description": "Routes requests to Anthropic Claude Haiku 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
             "anthropic.claude-haiku-4-5-20251001-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-5-20251101-v1:0",
           "profileName": "GLOBAL Anthropic Claude Opus 4.5",
           "description": "Routes requests to Anthropic Claude Opus 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-5-20251101-v1:0",
             "anthropic.claude-opus-4-5-20251101-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-6-v1",
           "profileName": "Global Anthropic Claude Opus 4.6",
           "description": "Routes requests to Anthropic Claude Opus 4.6 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-6-v1",
             "anthropic.claude-opus-4-6-v1"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-7",
           "profileName": "Global Anthropic Claude Opus 4.7",
           "description": "Routes requests to Anthropic Claude Opus 4.7 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-7",
             "anthropic.claude-opus-4-7"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
           "profileName": "Global Claude Sonnet 4.5",
           "description": "Routes requests to Claude Sonnet 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
             "anthropic.claude-sonnet-4-5-20250929-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-sonnet-4-6",
           "profileName": "Global Anthropic Claude Sonnet 4.6",
           "description": "Routes requests to Claude Sonnet 4.6 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-sonnet-4-6",
             "anthropic.claude-sonnet-4-6"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.cohere.embed-v4:0",
           "profileName": "Global Cohere Embed v4",
           "description": "Routes requests to Embed v4 globally across all supported AWS Regions.",
           "models": [
-            "cohere.embed-v4:0",
             "cohere.embed-v4:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.twelvelabs.pegasus-1-2-v1:0",
           "profileName": "GLOBAL TwelveLabs Pegasus v1.2",
           "description": "Routes requests to Pegasus v1.2 globally across all supported AWS Regions.",
           "models": [
-            "twelvelabs.pegasus-1-2-v1:0",
             "twelvelabs.pegasus-1-2-v1:0"
-          ]
+          ],
+          "routeRegions": []
         }
       ]
     },
@@ -12049,12 +12916,15 @@
           "description": "Routes requests to Nova Lite in ap-southeast-2, ap-northeast-1, ap-south-1, ap-northeast-2, ap-southeast-1 and ap-northeast-3.",
           "geo": "apac",
           "models": [
-            "amazon.nova-lite-v1:0",
-            "amazon.nova-lite-v1:0",
-            "amazon.nova-lite-v1:0",
-            "amazon.nova-lite-v1:0",
-            "amazon.nova-lite-v1:0",
             "amazon.nova-lite-v1:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-northeast-3",
+            "ap-south-1",
+            "ap-southeast-1",
+            "ap-southeast-2"
           ]
         },
         {
@@ -12063,12 +12933,15 @@
           "description": "Routes requests to Nova Micro in ap-southeast-2, ap-northeast-1, ap-south-1, ap-northeast-2, ap-southeast-1 and ap-northeast-3.",
           "geo": "apac",
           "models": [
-            "amazon.nova-micro-v1:0",
-            "amazon.nova-micro-v1:0",
-            "amazon.nova-micro-v1:0",
-            "amazon.nova-micro-v1:0",
-            "amazon.nova-micro-v1:0",
             "amazon.nova-micro-v1:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-northeast-3",
+            "ap-south-1",
+            "ap-southeast-1",
+            "ap-southeast-2"
           ]
         },
         {
@@ -12077,12 +12950,15 @@
           "description": "Routes requests to Nova Pro in ap-southeast-2, ap-northeast-1, ap-south-1, ap-northeast-2, ap-southeast-1 and ap-northeast-3.",
           "geo": "apac",
           "models": [
-            "amazon.nova-pro-v1:0",
-            "amazon.nova-pro-v1:0",
-            "amazon.nova-pro-v1:0",
-            "amazon.nova-pro-v1:0",
-            "amazon.nova-pro-v1:0",
             "amazon.nova-pro-v1:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-northeast-3",
+            "ap-south-1",
+            "ap-southeast-1",
+            "ap-southeast-2"
           ]
         },
         {
@@ -12091,11 +12967,14 @@
           "description": "Routes requests to Anthropic Claude 3.5 Sonnet in ap-northeast-1, ap-northeast-2, ap-southeast-1, ap-southeast-2 and ap-south-1.",
           "geo": "apac",
           "models": [
-            "anthropic.claude-3-5-sonnet-20240620-v1:0",
-            "anthropic.claude-3-5-sonnet-20240620-v1:0",
-            "anthropic.claude-3-5-sonnet-20240620-v1:0",
-            "anthropic.claude-3-5-sonnet-20240620-v1:0",
             "anthropic.claude-3-5-sonnet-20240620-v1:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-south-1",
+            "ap-southeast-1",
+            "ap-southeast-2"
           ]
         },
         {
@@ -12104,12 +12983,15 @@
           "description": "Routes requests to Anthropic Claude 3.5 Sonnet v2 in ap-northeast-1, ap-northeast-2, ap-northeast-3, ap-south-1, ap-southeast-1 and ap-southeast-2.",
           "geo": "apac",
           "models": [
-            "anthropic.claude-3-5-sonnet-20241022-v2:0",
-            "anthropic.claude-3-5-sonnet-20241022-v2:0",
-            "anthropic.claude-3-5-sonnet-20241022-v2:0",
-            "anthropic.claude-3-5-sonnet-20241022-v2:0",
-            "anthropic.claude-3-5-sonnet-20241022-v2:0",
             "anthropic.claude-3-5-sonnet-20241022-v2:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-northeast-3",
+            "ap-south-1",
+            "ap-southeast-1",
+            "ap-southeast-2"
           ]
         },
         {
@@ -12118,13 +13000,16 @@
           "description": "Routes requests to Anthropic Claude 3.7 Sonnet in ap-northeast-1, ap-northeast-2, ap-northeast-3, ap-south-1, ap-south-2, ap-southeast-1 and ap-southeast-2.",
           "geo": "apac",
           "models": [
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
             "anthropic.claude-3-7-sonnet-20250219-v1:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-northeast-3",
+            "ap-south-1",
+            "ap-south-2",
+            "ap-southeast-1",
+            "ap-southeast-2"
           ]
         },
         {
@@ -12133,11 +13018,14 @@
           "description": "Routes requests to Anthropic Claude 3 Haiku in ap-northeast-1, ap-northeast-2, ap-southeast-2, ap-south-1 and ap-southeast-1.",
           "geo": "apac",
           "models": [
-            "anthropic.claude-3-haiku-20240307-v1:0",
-            "anthropic.claude-3-haiku-20240307-v1:0",
-            "anthropic.claude-3-haiku-20240307-v1:0",
-            "anthropic.claude-3-haiku-20240307-v1:0",
             "anthropic.claude-3-haiku-20240307-v1:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-south-1",
+            "ap-southeast-1",
+            "ap-southeast-2"
           ]
         },
         {
@@ -12146,11 +13034,14 @@
           "description": "Routes requests to Anthropic Claude 3 Sonnet in ap-northeast-1, ap-northeast-2, ap-southeast-1, ap-southeast-2 and ap-south-1.",
           "geo": "apac",
           "models": [
-            "anthropic.claude-3-sonnet-20240229-v1:0",
-            "anthropic.claude-3-sonnet-20240229-v1:0",
-            "anthropic.claude-3-sonnet-20240229-v1:0",
-            "anthropic.claude-3-sonnet-20240229-v1:0",
             "anthropic.claude-3-sonnet-20240229-v1:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-south-1",
+            "ap-southeast-1",
+            "ap-southeast-2"
           ]
         },
         {
@@ -12159,14 +13050,17 @@
           "description": "Routes requests to Claude Sonnet 4 in ap-northeast-1, ap-northeast-2, ap-northeast-3, ap-south-1, ap-south-2, ap-southeast-1, ap-southeast-2 and ap-southeast-4.",
           "geo": "apac",
           "models": [
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
             "anthropic.claude-sonnet-4-20250514-v1:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-northeast-3",
+            "ap-south-1",
+            "ap-south-2",
+            "ap-southeast-1",
+            "ap-southeast-2",
+            "ap-southeast-4"
           ]
         }
       ],
@@ -12176,81 +13070,81 @@
           "profileName": "GLOBAL Amazon Nova 2 Lite",
           "description": "Routes requests to Amazon Nova 2 Lite globally across all supported AWS Regions.",
           "models": [
-            "amazon.nova-2-lite-v1:0",
             "amazon.nova-2-lite-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
           "profileName": "Global Anthropic Claude Haiku 4.5",
           "description": "Routes requests to Anthropic Claude Haiku 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
             "anthropic.claude-haiku-4-5-20251001-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-5-20251101-v1:0",
           "profileName": "GLOBAL Anthropic Claude Opus 4.5",
           "description": "Routes requests to Anthropic Claude Opus 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-5-20251101-v1:0",
             "anthropic.claude-opus-4-5-20251101-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-6-v1",
           "profileName": "Global Anthropic Claude Opus 4.6",
           "description": "Routes requests to Anthropic Claude Opus 4.6 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-6-v1",
             "anthropic.claude-opus-4-6-v1"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-7",
           "profileName": "Global Anthropic Claude Opus 4.7",
           "description": "Routes requests to Anthropic Claude Opus 4.7 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-7",
             "anthropic.claude-opus-4-7"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
           "profileName": "Global Claude Sonnet 4.5",
           "description": "Routes requests to Claude Sonnet 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
             "anthropic.claude-sonnet-4-5-20250929-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-sonnet-4-6",
           "profileName": "Global Anthropic Claude Sonnet 4.6",
           "description": "Routes requests to Claude Sonnet 4.6 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-sonnet-4-6",
             "anthropic.claude-sonnet-4-6"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.cohere.embed-v4:0",
           "profileName": "Global Cohere Embed v4",
           "description": "Routes requests to Embed v4 globally across all supported AWS Regions.",
           "models": [
-            "cohere.embed-v4:0",
             "cohere.embed-v4:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.twelvelabs.pegasus-1-2-v1:0",
           "profileName": "GLOBAL TwelveLabs Pegasus v1.2",
           "description": "Routes requests to Pegasus v1.2 globally across all supported AWS Regions.",
           "models": [
-            "twelvelabs.pegasus-1-2-v1:0",
             "twelvelabs.pegasus-1-2-v1:0"
-          ]
+          ],
+          "routeRegions": []
         }
       ]
     },
@@ -13023,12 +13917,15 @@
           "description": "Routes requests to Nova Lite in ap-southeast-2, ap-northeast-1, ap-south-1, ap-northeast-2, ap-southeast-1 and ap-northeast-3.",
           "geo": "apac",
           "models": [
-            "amazon.nova-lite-v1:0",
-            "amazon.nova-lite-v1:0",
-            "amazon.nova-lite-v1:0",
-            "amazon.nova-lite-v1:0",
-            "amazon.nova-lite-v1:0",
             "amazon.nova-lite-v1:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-northeast-3",
+            "ap-south-1",
+            "ap-southeast-1",
+            "ap-southeast-2"
           ]
         },
         {
@@ -13037,12 +13934,15 @@
           "description": "Routes requests to Nova Micro in ap-southeast-2, ap-northeast-1, ap-south-1, ap-northeast-2, ap-southeast-1 and ap-northeast-3.",
           "geo": "apac",
           "models": [
-            "amazon.nova-micro-v1:0",
-            "amazon.nova-micro-v1:0",
-            "amazon.nova-micro-v1:0",
-            "amazon.nova-micro-v1:0",
-            "amazon.nova-micro-v1:0",
             "amazon.nova-micro-v1:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-northeast-3",
+            "ap-south-1",
+            "ap-southeast-1",
+            "ap-southeast-2"
           ]
         },
         {
@@ -13051,12 +13951,15 @@
           "description": "Routes requests to Nova Pro in ap-southeast-2, ap-northeast-1, ap-south-1, ap-northeast-2, ap-southeast-1 and ap-northeast-3.",
           "geo": "apac",
           "models": [
-            "amazon.nova-pro-v1:0",
-            "amazon.nova-pro-v1:0",
-            "amazon.nova-pro-v1:0",
-            "amazon.nova-pro-v1:0",
-            "amazon.nova-pro-v1:0",
             "amazon.nova-pro-v1:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-northeast-3",
+            "ap-south-1",
+            "ap-southeast-1",
+            "ap-southeast-2"
           ]
         },
         {
@@ -13065,11 +13968,14 @@
           "description": "Routes requests to Anthropic Claude 3.5 Sonnet in ap-northeast-1, ap-northeast-2, ap-southeast-1, ap-southeast-2 and ap-south-1.",
           "geo": "apac",
           "models": [
-            "anthropic.claude-3-5-sonnet-20240620-v1:0",
-            "anthropic.claude-3-5-sonnet-20240620-v1:0",
-            "anthropic.claude-3-5-sonnet-20240620-v1:0",
-            "anthropic.claude-3-5-sonnet-20240620-v1:0",
             "anthropic.claude-3-5-sonnet-20240620-v1:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-south-1",
+            "ap-southeast-1",
+            "ap-southeast-2"
           ]
         },
         {
@@ -13078,12 +13984,15 @@
           "description": "Routes requests to Anthropic Claude 3.5 Sonnet v2 in ap-northeast-1, ap-northeast-2, ap-northeast-3, ap-south-1, ap-southeast-1 and ap-southeast-2.",
           "geo": "apac",
           "models": [
-            "anthropic.claude-3-5-sonnet-20241022-v2:0",
-            "anthropic.claude-3-5-sonnet-20241022-v2:0",
-            "anthropic.claude-3-5-sonnet-20241022-v2:0",
-            "anthropic.claude-3-5-sonnet-20241022-v2:0",
-            "anthropic.claude-3-5-sonnet-20241022-v2:0",
             "anthropic.claude-3-5-sonnet-20241022-v2:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-northeast-3",
+            "ap-south-1",
+            "ap-southeast-1",
+            "ap-southeast-2"
           ]
         },
         {
@@ -13092,13 +14001,16 @@
           "description": "Routes requests to Anthropic Claude 3.7 Sonnet in ap-northeast-1, ap-northeast-2, ap-northeast-3, ap-south-1, ap-south-2, ap-southeast-1 and ap-southeast-2.",
           "geo": "apac",
           "models": [
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
-            "anthropic.claude-3-7-sonnet-20250219-v1:0",
             "anthropic.claude-3-7-sonnet-20250219-v1:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-northeast-3",
+            "ap-south-1",
+            "ap-south-2",
+            "ap-southeast-1",
+            "ap-southeast-2"
           ]
         },
         {
@@ -13107,11 +14019,14 @@
           "description": "Routes requests to Anthropic Claude 3 Haiku in ap-northeast-1, ap-northeast-2, ap-southeast-2, ap-south-1 and ap-southeast-1.",
           "geo": "apac",
           "models": [
-            "anthropic.claude-3-haiku-20240307-v1:0",
-            "anthropic.claude-3-haiku-20240307-v1:0",
-            "anthropic.claude-3-haiku-20240307-v1:0",
-            "anthropic.claude-3-haiku-20240307-v1:0",
             "anthropic.claude-3-haiku-20240307-v1:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-south-1",
+            "ap-southeast-1",
+            "ap-southeast-2"
           ]
         },
         {
@@ -13120,11 +14035,14 @@
           "description": "Routes requests to Anthropic Claude 3 Sonnet in ap-northeast-1, ap-northeast-2, ap-southeast-1, ap-southeast-2 and ap-south-1.",
           "geo": "apac",
           "models": [
-            "anthropic.claude-3-sonnet-20240229-v1:0",
-            "anthropic.claude-3-sonnet-20240229-v1:0",
-            "anthropic.claude-3-sonnet-20240229-v1:0",
-            "anthropic.claude-3-sonnet-20240229-v1:0",
             "anthropic.claude-3-sonnet-20240229-v1:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-south-1",
+            "ap-southeast-1",
+            "ap-southeast-2"
           ]
         },
         {
@@ -13133,14 +14051,17 @@
           "description": "Routes requests to Claude Sonnet 4 in ap-northeast-1, ap-northeast-2, ap-northeast-3, ap-south-1, ap-south-2, ap-southeast-1, ap-southeast-2 and ap-southeast-4.",
           "geo": "apac",
           "models": [
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
             "anthropic.claude-sonnet-4-20250514-v1:0"
+          ],
+          "routeRegions": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-northeast-3",
+            "ap-south-1",
+            "ap-south-2",
+            "ap-southeast-1",
+            "ap-southeast-2",
+            "ap-southeast-4"
           ]
         },
         {
@@ -13149,8 +14070,11 @@
           "description": "Routes requests to Claude Haiku 4.5 in ap-southeast-2, ap-southeast-4.",
           "geo": "au",
           "models": [
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
             "anthropic.claude-haiku-4-5-20251001-v1:0"
+          ],
+          "routeRegions": [
+            "ap-southeast-2",
+            "ap-southeast-4"
           ]
         },
         {
@@ -13159,8 +14083,11 @@
           "description": "Routes requests to Claude Opus 4.6 in ap-southeast-2, ap-southeast-4.",
           "geo": "au",
           "models": [
-            "anthropic.claude-opus-4-6-v1",
             "anthropic.claude-opus-4-6-v1"
+          ],
+          "routeRegions": [
+            "ap-southeast-2",
+            "ap-southeast-4"
           ]
         },
         {
@@ -13169,8 +14096,11 @@
           "description": "Routes requests to AU Anthropic Claude Sonnet 4.5 in ap-southeast-2 and ap-southeast-4.",
           "geo": "au",
           "models": [
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
             "anthropic.claude-sonnet-4-5-20250929-v1:0"
+          ],
+          "routeRegions": [
+            "ap-southeast-2",
+            "ap-southeast-4"
           ]
         },
         {
@@ -13179,8 +14109,11 @@
           "description": "Routes requests to Claude Sonnet 4.6 in ap-southeast-2, ap-southeast-4.",
           "geo": "au",
           "models": [
-            "anthropic.claude-sonnet-4-6",
             "anthropic.claude-sonnet-4-6"
+          ],
+          "routeRegions": [
+            "ap-southeast-2",
+            "ap-southeast-4"
           ]
         }
       ],
@@ -13190,81 +14123,81 @@
           "profileName": "GLOBAL Amazon Nova 2 Lite",
           "description": "Routes requests to Amazon Nova 2 Lite globally across all supported AWS Regions.",
           "models": [
-            "amazon.nova-2-lite-v1:0",
             "amazon.nova-2-lite-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
           "profileName": "Global Anthropic Claude Haiku 4.5",
           "description": "Routes requests to Anthropic Claude Haiku 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-haiku-4-5-20251001-v1:0",
             "anthropic.claude-haiku-4-5-20251001-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-5-20251101-v1:0",
           "profileName": "GLOBAL Anthropic Claude Opus 4.5",
           "description": "Routes requests to Anthropic Claude Opus 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-5-20251101-v1:0",
             "anthropic.claude-opus-4-5-20251101-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-6-v1",
           "profileName": "Global Anthropic Claude Opus 4.6",
           "description": "Routes requests to Anthropic Claude Opus 4.6 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-6-v1",
             "anthropic.claude-opus-4-6-v1"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-opus-4-7",
           "profileName": "Global Anthropic Claude Opus 4.7",
           "description": "Routes requests to Anthropic Claude Opus 4.7 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-opus-4-7",
             "anthropic.claude-opus-4-7"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
           "profileName": "Global Claude Sonnet 4.5",
           "description": "Routes requests to Claude Sonnet 4.5 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-sonnet-4-5-20250929-v1:0",
             "anthropic.claude-sonnet-4-5-20250929-v1:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.anthropic.claude-sonnet-4-6",
           "profileName": "Global Anthropic Claude Sonnet 4.6",
           "description": "Routes requests to Claude Sonnet 4.6 globally across all supported AWS Regions.",
           "models": [
-            "anthropic.claude-sonnet-4-6",
             "anthropic.claude-sonnet-4-6"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.cohere.embed-v4:0",
           "profileName": "Global Cohere Embed v4",
           "description": "Routes requests to Embed v4 globally across all supported AWS Regions.",
           "models": [
-            "cohere.embed-v4:0",
             "cohere.embed-v4:0"
-          ]
+          ],
+          "routeRegions": []
         },
         {
           "profileId": "global.twelvelabs.pegasus-1-2-v1:0",
           "profileName": "GLOBAL TwelveLabs Pegasus v1.2",
           "description": "Routes requests to Pegasus v1.2 globally across all supported AWS Regions.",
           "models": [
-            "twelvelabs.pegasus-1-2-v1:0",
             "twelvelabs.pegasus-1-2-v1:0"
-          ]
+          ],
+          "routeRegions": []
         }
       ]
     }

--- a/public/index.html
+++ b/public/index.html
@@ -68,7 +68,8 @@
                 <th>Geo</th>
                 <th>Profile Name</th>
                 <th>Profile ID</th>
-                <th>Underlying Models</th>
+                <th>Model</th>
+                <th>Routes to</th>
               </tr>
             </thead>
             <tbody id="tbody-regional"></tbody>
@@ -90,7 +91,8 @@
               <tr>
                 <th>Profile Name</th>
                 <th>Profile ID</th>
-                <th>Underlying Models</th>
+                <th>Model</th>
+                <th>Routes to</th>
               </tr>
             </thead>
             <tbody id="tbody-global"></tbody>

--- a/public/styles.css
+++ b/public/styles.css
@@ -270,6 +270,19 @@ tbody tr:hover { background: color-mix(in srgb, var(--accent) 6%, transparent); 
   font-family: var(--mono);
 }
 
+.tag.empty-tag {
+  background: transparent;
+  font-family: inherit;
+  opacity: 0.5;
+}
+
+.tag.routes-all {
+  background: color-mix(in srgb, var(--accent) 18%, transparent);
+  color: var(--accent);
+  font-family: inherit;
+  font-weight: 500;
+}
+
 .yes { color: #2d7a5f; font-weight: 600; }
 .no { color: var(--muted); }
 

--- a/scripts/fetch-data.ts
+++ b/scripts/fetch-data.ts
@@ -62,6 +62,7 @@ type Profile = {
   description?: string;
   geo?: string;
   models: string[];
+  routeRegions: string[];
 };
 
 type RegionData = {
@@ -105,15 +106,26 @@ function mapModel(m: FoundationModelSummary): OnDemandModel {
 
 function mapProfile(p: InferenceProfileSummary): Profile {
   const id = p.inferenceProfileId ?? "";
+  const arns = (p.models ?? [])
+    .map((m) => m.modelArn ?? "")
+    .filter(Boolean);
+  // ARN shape: arn:aws:bedrock:<region>:<account>:foundation-model/<modelId>
+  // Each entry in p.models represents one route-through region, so model IDs
+  // are usually duplicated N times. Dedupe and surface the regions separately
+  // so the UI can show "which regions does this profile route through".
+  const models = [
+    ...new Set(arns.map((arn) => arn.split("/").pop() ?? arn)),
+  ].sort();
+  const routeRegions = [
+    ...new Set(arns.map((arn) => arn.split(":")[3] ?? "").filter(Boolean)),
+  ].sort();
   return {
     profileId: id,
     profileName: p.inferenceProfileName,
     description: p.description,
     geo: geoFromProfile(id),
-    models: (p.models ?? [])
-      .map((m) => m.modelArn ?? "")
-      .filter(Boolean)
-      .map((arn) => arn.split("/").pop() ?? arn),
+    models,
+    routeRegions,
   };
 }
 


### PR DESCRIPTION
## What you were seeing

![before](https://user-images.githubusercontent.com/placeholder/before.png)

The "Underlying Models" column rendered the same model ID 2-3 times per profile, e.g.:

```
US Amazon Nova 2 Lite  →  amazon.nova-2-lite-v1:0  amazon.nova-2-lite-v1:0  amazon.nova-2-lite-v1:0
```

You spotted that the duplication was *accidentally* trying to say "where they're coming from" — and you were right. It was encoding that info in the worst possible way (duplicate count) instead of just showing the regions.

## Why it happened

`ListInferenceProfiles` returns `models[]` as an array with one entry **per route region** the profile can dispatch to. Each entry contains its own `modelArn`, e.g.:

```
arn:aws:bedrock:us-east-1:ACCT:foundation-model/amazon.nova-2-lite-v1:0
arn:aws:bedrock:us-east-2:ACCT:foundation-model/amazon.nova-2-lite-v1:0
arn:aws:bedrock:us-west-2:ACCT:foundation-model/amazon.nova-2-lite-v1:0
```

Old mapper: `arn.split("/").pop()` → three identical model IDs.
New mapper: dedupe model IDs AND capture the regions.

## After

```
GEO   PROFILE NAME            PROFILE ID                  MODEL                       ROUTES TO
US    US Amazon Nova 2 Lite   us.amazon.nova-2-lite-v1:0  amazon.nova-2-lite-v1:0    us-east-1  us-east-2  us-west-2
US    US Nova Lite            us.amazon.nova-lite-v1:0    amazon.nova-lite-v1:0      us-east-1  us-east-2  us-west-2
```

For `global.*` profiles whose AWS description says "globally across all supported AWS Regions", the Routes-to cell shows a single styled pill: **All commercial regions**.

## Files changed

| File | Change |
|---|---|
| `scripts/fetch-data.ts` | Parse ARN once, extract modelId + region. Emit deduped `models[]` + new `routeRegions[]`. Sort both. |
| `public/app.js` | Render one tag per distinct model; add Routes-to column; special pill for all-regions global profiles; defensive `uniq()` for any stale data. |
| `public/index.html` | Add `Routes to` column header to Regional and Global tables. |
| `public/styles.css` | `.empty-tag` (faint em-dash) and `.routes-all` (accent pill) styles. |
| `public/data.json` | Post-processed: **1111** redundant model entries removed, **311** profiles back-filled with `routeRegions` from description text. The remaining 156 (mostly `global.*` with "globally" descriptions) populate fully on the next real fetch via ARN parsing. |

## Data shape change

`Profile`:

```diff
 type Profile = {
   profileId: string;
   profileName?: string;
   description?: string;
   geo?: string;
-  models: string[];           // was: duplicated per route region
+  models: string[];           // now: deduped
+  routeRegions: string[];     // NEW: regions this profile dispatches to
 };
```

Nothing breaks the `diff-data.ts` alerting script because it keys off `profileId` set membership, not the inner `models[]`.

## Test plan

- [x] Local typecheck: `bunx tsc --noEmit` pass
- [x] Local serve: table headers include `Model` and `Routes to`
- [x] Spot check 3 profiles from your screenshot: all now show 1 model + correct regions
- [x] `au.anthropic.claude-sonnet-4-6` → `ap-southeast-2, ap-southeast-4` (matches AWS docs)
- [ ] Merge, confirm deployed site renders cleanly
- [ ] Next nightly fetch enriches the final 156 global profiles with exact source regions
