### PR TITLE
feat(alerts): open GitHub issue when Bedrock catalog changes

### DIFF
--- a/.github/workflows/refresh-data.yml
+++ b/.github/workflows/refresh-data.yml
@@ -9,6 +9,7 @@ permissions:
   id-token: write
   contents: write
   pull-requests: write
+  issues: write
 
 concurrency:
   group: refresh-data
@@ -56,38 +57,31 @@ jobs:
           role-session-name: bedrock-region-viewer-refresh
           mask-aws-account-id: true
 
+      - name: Save previous snapshot
+        run: cp public/data.json /tmp/previous.json
+
       - name: Snapshot Bedrock catalog
         run: bun run fetch
 
-      - name: Detect changes
+      - name: Diff catalog against previous snapshot
         id: diff
         run: |
-          if git diff --quiet -- public/data.json; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=true" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          RESULT=$(bun run scripts/diff-data.ts /tmp/previous.json public/data.json)
+          HAS=$(echo "$RESULT" | jq -r .hasChanges)
+          echo "changed=$HAS" >> "$GITHUB_OUTPUT"
+          if [ "$HAS" = "true" ]; then
+            echo "$RESULT" | jq -r .title > /tmp/issue-title.txt
+            echo "$RESULT" | jq -r .body > /tmp/issue-body.md
             {
-              echo "summary<<EOF"
-              bun -e '
-                const d = await Bun.file("public/data.json").json();
-                const ok = Object.keys(d.regions).length;
-                const fail = Object.keys(d.errors ?? {}).length;
-                let totalOnDemand = 0, totalRegional = 0, totalGlobal = 0;
-                for (const r of Object.values(d.regions)) {
-                  totalOnDemand += (r.onDemand ?? []).length;
-                  totalRegional += (r.regional ?? []).length;
-                  totalGlobal += (r.global ?? []).length;
-                }
-                console.log(`Generated: ${d.generatedAt}`);
-                console.log(`Regions ok: ${ok}`);
-                console.log(`Regions with errors: ${fail}`);
-                console.log(`Entries: onDemand=${totalOnDemand} regional=${totalRegional} global=${totalGlobal}`);
-              '
-              echo "EOF"
-            } >> "$GITHUB_OUTPUT"
+              echo "## Catalog changes detected"
+              echo "$RESULT" | jq -r .body
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No model availability changes." >> "$GITHUB_STEP_SUMMARY"
           fi
 
-      - name: Open PR with data.json update
+      - name: Open PR and create tracking issue
         if: steps.diff.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -102,22 +96,30 @@ jobs:
           git commit -m "chore(data): nightly Bedrock catalog refresh ${DATE}"
           git push -u origin "$BRANCH"
 
-          BODY=$(cat <<BODYEOF
-          Automated nightly refresh of \`public/data.json\` from the AWS Bedrock APIs.
+          # Ensure labels exist (idempotent).
+          gh label create model-changes --color FBCA04 --description "Automated alert when Bedrock catalog model/profile availability changes" --force >/dev/null
+          gh label create automated --color EDEDED --description "Opened by automation" --force >/dev/null
 
-          \`\`\`
-          ${{ steps.diff.outputs.summary }}
-          \`\`\`
+          # Create the tracking issue first; capture URL to link from the PR.
+          ISSUE_URL=$(gh issue create \
+            --title "$(cat /tmp/issue-title.txt)" \
+            --body-file /tmp/issue-body.md \
+            --label model-changes,automated)
 
-          This PR only modifies \`public/data.json\`. Auto-merge is enabled; it will squash-merge once required checks pass.
-          BODYEOF
-          )
+          # PR body references the issue.
+          {
+            echo "Automated nightly refresh of \`public/data.json\` from the AWS Bedrock APIs."
+            echo ""
+            echo "Model availability changes tracked in ${ISSUE_URL}."
+            echo ""
+            echo "This PR only modifies \`public/data.json\`. Auto-merge is enabled; it will squash-merge once required checks pass."
+          } > /tmp/pr-body.md
 
           gh pr create \
             --base main \
             --head "$BRANCH" \
             --title "chore(data): nightly refresh ${DATE}" \
-            --body "$BODY" \
-            --label automated,data-refresh
+            --body-file /tmp/pr-body.md \
+            --label automated
 
           gh pr merge --auto --squash --delete-branch "$BRANCH"

--- a/README.md
+++ b/README.md
@@ -115,18 +115,45 @@ gh workflow run deploy-amplify.yml
 # or: push any change touching public/
 ```
 
-## Nightly data refresh
+## Nightly data refresh + change alerts
 
 `refresh-data.yml` runs at **14:00 UTC** (≈ midnight AEST / 01:00 AEDT). It:
 
-1. Assumes `AWS_ROLE_ARN` via OIDC.
-2. Runs `bun run fetch` → writes new `public/data.json`.
-3. If the file changed: commits **only `public/data.json`** to `data/nightly-<date>` and opens a PR with auto-merge (squash) enabled.
-4. On merge, `deploy-amplify.yml` fires and redeploys the static bundle.
+1. Saves the current `public/data.json` as a baseline (pre-fetch).
+2. Assumes `AWS_ROLE_ARN` via OIDC.
+3. Runs `bun run fetch` → writes a new `public/data.json`.
+4. Runs `bun run scripts/diff-data.ts` comparing baseline vs new. It ignores `generatedAt` and `errors` — only tracks model/profile ID set membership across `onDemand`, `regional`, and `global`.
+5. **If no model availability changes** → silent no-op. No PR, no issue, no noise.
+6. **If changes detected** → opens a GitHub **issue** summarizing the delta (aggregate + per-region breakdown) AND a PR committing the new `data.json` with auto-merge enabled. The PR body links back to the issue.
 
-If no diff, the workflow is a no-op. No PRs when the catalog is unchanged.
+On merge, `deploy-amplify.yml` fires and redeploys the static bundle.
 
-Why a PR instead of direct push: repo policy is **no direct pushes to `main`**. The workflow stages only `public/data.json`, so the PR diff is mechanically guaranteed to be data-only.
+### Issue format
+
+Title: `Bedrock catalog changes: +N models, -M models, +P profiles (YYYY-MM-DD)`
+
+Body (abbreviated):
+```
+## New
+### On-demand models
+- `anthropic.claude-opus-4-7`
+
+### Inference profiles
+- `us.anthropic.claude-opus-4-7`
+- `global.anthropic.claude-opus-4-7`
+
+## Per-region breakdown
+#### us-east-1
+- +on-demand `anthropic.claude-opus-4-7`
+- +regional `us.anthropic.claude-opus-4-7`
+- +global `global.anthropic.claude-opus-4-7`
+```
+
+Subscribe to issues (or filter on the `model-changes` label) to get pinged when AWS adds or removes a model. The same markdown also lands in the workflow step summary — visible in the Actions tab without needing to click through.
+
+### Why a PR instead of direct push
+
+Repo policy is **no direct pushes to `main`**. The workflow stages only `public/data.json`, so the PR diff is mechanically guaranteed to be data-only.
 
 ## Regenerating data locally
 

--- a/scripts/diff-data.ts
+++ b/scripts/diff-data.ts
@@ -1,0 +1,143 @@
+import { readFile } from "node:fs/promises";
+
+type Delta = {
+  region: string;
+  addedOnDemand: string[];
+  removedOnDemand: string[];
+  addedRegional: string[];
+  removedRegional: string[];
+  addedGlobal: string[];
+  removedGlobal: string[];
+};
+
+const [, , oldPath, newPath] = process.argv;
+if (!oldPath || !newPath) {
+  console.error("usage: bun scripts/diff-data.ts <old.json> <new.json>");
+  process.exit(2);
+}
+
+const oldData = JSON.parse(await readFile(oldPath, "utf8"));
+const newData = JSON.parse(await readFile(newPath, "utf8"));
+
+const ids = (arr: unknown, key: string): Set<string> => {
+  if (!Array.isArray(arr)) return new Set();
+  return new Set(arr.map((x: Record<string, unknown>) => String(x[key] ?? "")).filter(Boolean));
+};
+
+const setDiff = (prev: Set<string>, next: Set<string>) => ({
+  added: [...next].filter((x) => !prev.has(x)).sort(),
+  removed: [...prev].filter((x) => !next.has(x)).sort(),
+});
+
+const allRegions = new Set<string>([
+  ...Object.keys(oldData.regions ?? {}),
+  ...Object.keys(newData.regions ?? {}),
+]);
+
+const deltas: Delta[] = [];
+for (const region of [...allRegions].sort()) {
+  const o = oldData.regions?.[region] ?? { onDemand: [], regional: [], global: [] };
+  const n = newData.regions?.[region] ?? { onDemand: [], regional: [], global: [] };
+  const od = setDiff(ids(o.onDemand, "modelId"), ids(n.onDemand, "modelId"));
+  const rg = setDiff(ids(o.regional, "profileId"), ids(n.regional, "profileId"));
+  const gl = setDiff(ids(o.global, "profileId"), ids(n.global, "profileId"));
+  if (
+    od.added.length || od.removed.length ||
+    rg.added.length || rg.removed.length ||
+    gl.added.length || gl.removed.length
+  ) {
+    deltas.push({
+      region,
+      addedOnDemand: od.added,
+      removedOnDemand: od.removed,
+      addedRegional: rg.added,
+      removedRegional: rg.removed,
+      addedGlobal: gl.added,
+      removedGlobal: gl.removed,
+    });
+  }
+}
+
+if (deltas.length === 0) {
+  console.log(JSON.stringify({ hasChanges: false }));
+  process.exit(0);
+}
+
+const uniqAddedOnDemand = new Set<string>();
+const uniqRemovedOnDemand = new Set<string>();
+const uniqAddedProfiles = new Set<string>();
+const uniqRemovedProfiles = new Set<string>();
+
+for (const d of deltas) {
+  d.addedOnDemand.forEach((x) => uniqAddedOnDemand.add(x));
+  d.removedOnDemand.forEach((x) => uniqRemovedOnDemand.add(x));
+  [...d.addedRegional, ...d.addedGlobal].forEach((x) => uniqAddedProfiles.add(x));
+  [...d.removedRegional, ...d.removedGlobal].forEach((x) => uniqRemovedProfiles.add(x));
+}
+
+const titleParts: string[] = [];
+if (uniqAddedOnDemand.size) titleParts.push(`+${uniqAddedOnDemand.size} model${uniqAddedOnDemand.size === 1 ? "" : "s"}`);
+if (uniqRemovedOnDemand.size) titleParts.push(`-${uniqRemovedOnDemand.size} model${uniqRemovedOnDemand.size === 1 ? "" : "s"}`);
+if (uniqAddedProfiles.size) titleParts.push(`+${uniqAddedProfiles.size} profile${uniqAddedProfiles.size === 1 ? "" : "s"}`);
+if (uniqRemovedProfiles.size) titleParts.push(`-${uniqRemovedProfiles.size} profile${uniqRemovedProfiles.size === 1 ? "" : "s"}`);
+
+const datePart = String(newData.generatedAt ?? "").slice(0, 10);
+const title = `Bedrock catalog changes: ${titleParts.join(", ")} (${datePart})`;
+
+const lines: string[] = [];
+lines.push(`Snapshot **${newData.generatedAt}** compared to the previous commit on \`main\`.`);
+lines.push("");
+lines.push(`**${deltas.length}** region${deltas.length === 1 ? "" : "s"} with changes across ${allRegions.size} tracked regions.`);
+lines.push("");
+
+const section = (header: string, items: Set<string>) => {
+  if (!items.size) return;
+  lines.push(`### ${header}`);
+  for (const x of [...items].sort()) lines.push(`- \`${x}\``);
+  lines.push("");
+};
+
+if (uniqAddedOnDemand.size || uniqAddedProfiles.size) {
+  lines.push("## New");
+  section("On-demand models", uniqAddedOnDemand);
+  section("Inference profiles", uniqAddedProfiles);
+}
+
+if (uniqRemovedOnDemand.size || uniqRemovedProfiles.size) {
+  lines.push("## Removed");
+  section("On-demand models", uniqRemovedOnDemand);
+  section("Inference profiles", uniqRemovedProfiles);
+}
+
+lines.push("## Per-region breakdown");
+lines.push("");
+lines.push("<details>");
+lines.push("<summary>Expand</summary>");
+lines.push("");
+for (const d of deltas) {
+  lines.push(`#### \`${d.region}\``);
+  const fmt = (xs: string[]) => xs.map((x) => `\`${x}\``).join(", ");
+  if (d.addedOnDemand.length) lines.push(`- **+on-demand** ${fmt(d.addedOnDemand)}`);
+  if (d.removedOnDemand.length) lines.push(`- **-on-demand** ${fmt(d.removedOnDemand)}`);
+  if (d.addedRegional.length) lines.push(`- **+regional** ${fmt(d.addedRegional)}`);
+  if (d.removedRegional.length) lines.push(`- **-regional** ${fmt(d.removedRegional)}`);
+  if (d.addedGlobal.length) lines.push(`- **+global** ${fmt(d.addedGlobal)}`);
+  if (d.removedGlobal.length) lines.push(`- **-global** ${fmt(d.removedGlobal)}`);
+  lines.push("");
+}
+lines.push("</details>");
+lines.push("");
+lines.push(`Auto-opened by the nightly \`refresh-data\` workflow. The accompanying PR updates \`public/data.json\` and auto-merges once checks pass.`);
+
+console.log(JSON.stringify({
+  hasChanges: true,
+  title,
+  body: lines.join("\n"),
+  stats: {
+    regionsChanged: deltas.length,
+    addedModels: uniqAddedOnDemand.size,
+    removedModels: uniqRemovedOnDemand.size,
+    addedProfiles: uniqAddedProfiles.size,
+    removedProfiles: uniqRemovedProfiles.size,
+  },
+}));


### PR DESCRIPTION
## Goal

Get alerted when AWS changes what models are available in Bedrock. Right now the nightly refresh opens a PR on any `generatedAt` bump and doesn't summarize what changed — this fixes both.

> This is a fresh branch off the post-merge `main`. Supersedes `feat/issue-on-model-changes` (abandoned after its base branch was deleted during the PR #1 squash-merge).

## New behavior

Old flow (post-PR #1): `fetch` → if `data.json` diff → open PR.
New flow (this PR): `fetch` → **diff model IDs vs previous snapshot** → silent if no real changes, otherwise **issue + PR**.

```
(no model changes)                              (model changes detected)
┌──────────────────────────┐                   ┌──────────────────────────┐
│ bun run fetch            │                   │ bun run fetch            │
│ bun run scripts/diff-... │                   │ bun run scripts/diff-... │
│ hasChanges=false         │                   │ hasChanges=true          │
│ (silent no-op)           │                   │ ↓                        │
└──────────────────────────┘                   │ gh issue create (alert)  │
                                               │ gh pr create (auto-merge)│
                                               │ step summary = diff md   │
                                               └──────────────────────────┘
```

## What's in the diff

- **Ignores**: `generatedAt`, `errors` (fluctuate per run without meaning)
- **Tracks**: model/profile ID set membership across:
  - `regions.<region>.onDemand[].modelId`
  - `regions.<region>.regional[].profileId`
  - `regions.<region>.global[].profileId`

## Issue format

Title: `Bedrock catalog changes: +N models, -M models, +P profiles (YYYY-MM-DD)`

Body (verified against synthetic fixture):

```
Snapshot 2026-04-21T00:00:00Z compared to the previous commit on main.

2 regions with changes across 2 tracked regions.

## New
### On-demand models
- anthropic.claude-opus-4-7

### Inference profiles
- us.anthropic.claude-opus-4-7
- global.anthropic.claude-opus-4-7

## Removed
### On-demand models
- old.legacy-model-v1:0

## Per-region breakdown
<details>
#### eu-west-1
- +on-demand anthropic.claude-new-region-v1:0
#### us-east-1
- +on-demand anthropic.claude-opus-4-7
- -on-demand old.legacy-model-v1:0
- +regional us.anthropic.claude-opus-4-7
- +global global.anthropic.claude-opus-4-7
</details>
```

Same markdown lands in the Actions step summary.

## Files

- **New**: `scripts/diff-data.ts` — pure function on two data.json files, outputs JSON `{hasChanges, title, body, stats}`
- **Changed**: `.github/workflows/refresh-data.yml` — save baseline → fetch → diff → issue + PR on change; `issues: write` added; idempotent `gh label create --force` for `model-changes` / `automated`
- **Changed**: `README.md` — "Nightly data refresh + change alerts" section

## Test plan

- [x] Local typecheck: `bunx tsc --noEmit` — pass
- [x] Local YAML parse on both workflows — pass
- [x] Identical-input fixture: `{hasChanges:false}` and clean exit
- [x] Synthetic delta fixture (added model, added profile, removed model): correct title, body, stats
- [ ] Post-merge: `workflow_dispatch` refresh-data once → confirm silent exit when no catalog changes
- [ ] When AWS next adds a model: confirm issue appears with accurate delta
