### PR TITLE
fix(ci): clean up orphan branch when PR creation is blocked

### DIFF
--- a/.github/workflows/refresh-data.yml
+++ b/.github/workflows/refresh-data.yml
@@ -87,8 +87,26 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
+
           DATE=$(date -u +%Y-%m-%d-%H%M)
           BRANCH="data/nightly-${DATE}"
+          PR_CREATED=0
+
+          # If anything fails after we've pushed the branch but before the PR
+          # exists, delete the orphan branch so the remote stays clean. Past
+          # failures (e.g. "GitHub Actions is not permitted to create or
+          # approve pull requests" when the repo setting is off) left these
+          # branches lingering.
+          cleanup() {
+            local rc=$?
+            if [ "$rc" -ne 0 ] && [ "$PR_CREATED" -eq 0 ]; then
+              echo "::warning::PR creation did not complete. Deleting orphan branch ${BRANCH}."
+              git push origin --delete "${BRANCH}" 2>/dev/null || true
+            fi
+            return $rc
+          }
+          trap cleanup EXIT
+
           git config user.name "bedrock-catalog-bot"
           git config user.email "bot@users.noreply.github.com"
           git checkout -b "$BRANCH"
@@ -101,6 +119,8 @@ jobs:
           gh label create automated --color EDEDED --description "Opened by automation" --force >/dev/null
 
           # Create the tracking issue first; capture URL to link from the PR.
+          # Issue creation does not require the "Allow Actions to create PRs"
+          # repo setting, so this still fires even if PR creation is blocked.
           ISSUE_URL=$(gh issue create \
             --title "$(cat /tmp/issue-title.txt)" \
             --body-file /tmp/issue-body.md \
@@ -115,11 +135,20 @@ jobs:
             echo "This PR only modifies \`public/data.json\`. Auto-merge is enabled; it will squash-merge once required checks pass."
           } > /tmp/pr-body.md
 
-          gh pr create \
+          # gh pr create can fail with a confusing error when the repo
+          # setting "Allow GitHub Actions to create and approve pull requests"
+          # is OFF (Settings -> Actions -> General -> Workflow permissions).
+          # workflow `permissions: pull-requests: write` is necessary but not
+          # sufficient on its own.
+          if ! gh pr create \
             --base main \
             --head "$BRANCH" \
             --title "chore(data): nightly refresh ${DATE}" \
             --body-file /tmp/pr-body.md \
-            --label automated
+            --label automated; then
+            echo "::error::gh pr create failed. Most likely cause: the repo setting 'Allow GitHub Actions to create and approve pull requests' is OFF. Enable it at: Settings -> Actions -> General -> Workflow permissions. The orphan branch ${BRANCH} will be deleted automatically; the tracking issue ${ISSUE_URL} remains as a record of the catalog change."
+            exit 1
+          fi
+          PR_CREATED=1
 
           gh pr merge --auto --squash --delete-branch "$BRANCH"


### PR DESCRIPTION
## What broke

Last night's `Refresh Bedrock catalog` run ([24933261815](https://github.com/sjramblings/bedrock-region-viewer/actions/runs/24933261815/job/73014428245)) failed with:

```
pull request create failed: GraphQL: GitHub Actions is not permitted to create
or approve pull requests (createPullRequest)
Error: Process completed with exit code 1.
```

The push to `data/nightly-2026-04-25-1444` had already succeeded, so the failure left an orphan branch on the remote.

## Root cause

The error is **not** about the workflow's `permissions:` block — that already declares `pull-requests: write`. It's about a **separate repo-level setting** that overrides workflow permissions:

> Settings → Actions → General → Workflow permissions →
> ☐ **Allow GitHub Actions to create and approve pull requests**

This box is **off by default on every GitHub repo**. Enable it (one-time, manual) and `gh pr create` from `GITHUB_TOKEN` works. Same fix via API:

```bash
gh api -X PUT repos/sjramblings/bedrock-region-viewer/actions/permissions/workflow \
  --field default_workflow_permissions=write \
  --field can_approve_pull_requests=true
```

## What this PR changes (workflow hardening)

- **EXIT trap** that deletes the pushed branch when `gh pr create` fails. Sets `PR_CREATED=1` after a successful PR call so cleanup is skipped on the happy path.
- **Explicit `::error::` annotation** that names the actual cause (the repo setting) and points at where to flip it. The current "GitHub Actions is not permitted to create…" message is opaque if you don't already know about that setting.
- **Source comment** linking the symptom to the fix, so the next person debugging this doesn't have to rediscover it.
- The **tracking issue is still created** (issue creation isn't gated by the PR setting), so even when the PR step fails the catalog change is preserved as a record.

## Manual cleanup (after merge)

The orphan branch from the failed run can be deleted now:

```bash
gh api -X DELETE repos/sjramblings/bedrock-region-viewer/git/refs/heads/data%2Fnightly-2026-04-25-1444
```

Or wait for next nightly — it'll only delete its own orphans, not retroactively.

## Test plan

- [x] Local YAML parse — pass
- [ ] Merge this PR
- [ ] Flip the repo setting (manual)
- [ ] `gh workflow run refresh-data.yml` to verify the next run completes the full chain (issue + PR + auto-merge)
