### PR TITLE
fix(ci): trigger Amplify deploy after nightly catalog refresh

### DIFF
--- a/.github/workflows/deploy-amplify.yml
+++ b/.github/workflows/deploy-amplify.yml
@@ -6,6 +6,17 @@ on:
     paths:
       - "public/**"
       - ".github/workflows/deploy-amplify.yml"
+  # Catch the case where the nightly Refresh Bedrock catalog workflow
+  # auto-merges its data PR. That merge is authored by github-actions[bot]
+  # via GITHUB_TOKEN, and GitHub deliberately suppresses subsequent push
+  # events from GITHUB_TOKEN to prevent recursive workflow runs (see
+  # https://docs.github.com/en/actions/security-for-github-actions/
+  # security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow).
+  # Without this trigger, refreshed data sits on main without being deployed.
+  workflow_run:
+    workflows: ["Refresh Bedrock catalog"]
+    types: [completed]
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -18,6 +29,11 @@ concurrency:
 
 jobs:
   preflight:
+    # Skip when the upstream Refresh Bedrock catalog run failed or was
+    # cancelled. push and workflow_dispatch always proceed.
+    if: >
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     outputs:
       ready: ${{ steps.check.outputs.ready }}


### PR DESCRIPTION
## Why this exists

PR [#9](https://github.com/sjramblings/bedrock-region-viewer/pull/9) (nightly data refresh) merged cleanly, but the live site never updated. Confirmed:

```bash
$ gh api repos/sjramblings/bedrock-region-viewer/commits/5045083 -q '.author.login'
github-actions[bot]
```

```bash
$ gh run list --workflow deploy-amplify.yml --limit 5
24725016037 push completed/success created=2026-04-21T13:27:14Z
24723693214 push completed/success created=2026-04-21T12:59:05Z
```

Last `deploy-amplify` run was 7 days ago. Five nightly refreshes since. None deployed.

## Root cause

When `refresh-data` calls `gh pr merge --auto`, the resulting commit on `main` is authored by `github-actions[bot]` via `GITHUB_TOKEN`. GitHub deliberately **suppresses** push events generated by `GITHUB_TOKEN` to prevent recursive workflow loops:

> "Events triggered by the `GITHUB_TOKEN`, with the exception of `workflow_dispatch` and `repository_dispatch`, will not create a new workflow run." — [GitHub docs](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow)

So `on: push paths: public/**` never fires. The data lands on `main` but nothing redeploys.

## Fix

Add a `workflow_run` trigger to `deploy-amplify` that listens for `refresh-data` completion. `workflow_run` is one of the loophole events that **does** fire from `GITHUB_TOKEN`-authored activity, so this catches the auto-merge case.

```yaml
on:
  push:
    branches: [main]
    paths: ["public/**", ".github/workflows/deploy-amplify.yml"]
  workflow_run:
    workflows: ["Refresh Bedrock catalog"]
    types: [completed]
    branches: [main]
  workflow_dispatch:
```

Plus a guard so we don't deploy after a failed/cancelled refresh:

```yaml
preflight:
  if: >
    github.event_name != 'workflow_run' ||
    github.event.workflow_run.conclusion == 'success'
```

## Why no race condition

By the time `workflow_run` fires, the auto-merge commit is already on `main`:

| Event | Timestamp |
|---|---|
| PR #9 merged | `12:29:48Z` |
| `refresh-data` workflow completed | `12:29:54Z` |

Auto-merge with no required checks fires synchronously inside the `gh pr merge` call. So `checkout` in deploy-amplify pulls the latest `data.json`.

## What about other approaches I considered?

| Option | Why not |
|---|---|
| Use a fine-grained PAT for `gh pr merge` so push events fire normally | Adds another secret to rotate; PR shows up under your account, not the bot |
| Replace `--auto` with synchronous `--merge` plus explicit `gh workflow run` | More steps, more failure modes, requires polling for merge completion |
| `repository_dispatch` from refresh-data | Same outcome as `workflow_run`, more code |

`workflow_run` is the smallest change that closes the loop.

## Already done in parallel

Triggered a manual `gh workflow run deploy-amplify.yml` (run [25053203302](https://github.com/sjramblings/bedrock-region-viewer/actions/runs/25053203302)) so the live site catches up to the merged PR #9 data **immediately**, without waiting for this PR to land.

## Test plan

- [x] Local YAML parse — pass
- [x] Manual dispatch verified to still work (run 25053203302 in flight)
- [ ] Merge this PR
- [ ] Tonight's scheduled refresh: if catalog changes, refresh-data → issue → PR → auto-merge → workflow_run fires → deploy-amplify runs → site updates
- [ ] If catalog has no changes: refresh-data exits silent (no PR), workflow_run still fires deploy-amplify, **harmlessly redeploys identical content** (~30s of CI, negligible Amplify cost)
