### PR TITLE
feat: byte-stable data.json + history-depth trigger at 90 commits

### DIFF
--- a/.github/workflows/refresh-data.yml
+++ b/.github/workflows/refresh-data.yml
@@ -152,3 +152,28 @@ jobs:
           PR_CREATED=1
 
           gh pr merge --auto --squash --delete-branch "$BRANCH"
+
+      - name: History-depth trigger (start time-series dashboard at ~90 commits)
+        if: always()
+        run: |
+          set -euo pipefail
+          # Count commits that touched public/data.json on origin/main so the
+          # number reflects what is actually on the default branch — not the
+          # ephemeral nightly branch this run may have just created. Threshold
+          # of 90 is roughly three months of nightly data, the point at which
+          # a git-history-as-time-series dashboard (mirroring the aws-ip-ranges
+          # pattern) becomes worth building.
+          git fetch origin main --depth=200 >/dev/null 2>&1 || true
+          COUNT=$(git log origin/main --oneline -- public/data.json 2>/dev/null | wc -l | tr -d ' ')
+          echo "## Data history depth" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`public/data.json\` has **${COUNT}** commits on \`main\`." >> "$GITHUB_STEP_SUMMARY"
+          if [ "${COUNT}" -ge 90 ]; then
+            echo "::notice::data.json has ${COUNT} commits on main — threshold of 90 reached. Time to start the time-series dashboard port (see aws-ip-ranges pattern)."
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "**🚦 Trigger fired** — threshold of 90 reached. Time to start the time-series dashboard port. See \`sjramblings/aws-ip-ranges\` for the reference pattern." >> "$GITHUB_STEP_SUMMARY"
+          else
+            REMAINING=$((90 - COUNT))
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "${REMAINING} more commit$([ "$REMAINING" -eq 1 ] && echo "" || echo "s") until the time-series dashboard trigger fires." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/scripts/fetch-data.ts
+++ b/scripts/fetch-data.ts
@@ -93,13 +93,17 @@ function geoFromProfile(profileId: string): string | undefined {
 }
 
 function mapModel(m: FoundationModelSummary): OnDemandModel {
+  // Sort modality + inferenceType arrays — AWS does not guarantee order,
+  // and unsorted arrays produce spurious git diffs when only the ordering
+  // shuffled. Sets fed to diff-data.ts ignore order, but the raw git diff
+  // is what humans (and any future commit-by-commit extractor) read.
   return {
     modelId: m.modelId ?? "",
     providerName: m.providerName,
     modelName: m.modelName,
-    inputModalities: m.inputModalities ?? [],
-    outputModalities: m.outputModalities ?? [],
-    inferenceTypesSupported: m.inferenceTypesSupported ?? [],
+    inputModalities: [...(m.inputModalities ?? [])].sort(),
+    outputModalities: [...(m.outputModalities ?? [])].sort(),
+    inferenceTypesSupported: [...(m.inferenceTypesSupported ?? [])].sort(),
     responseStreamingSupported: m.responseStreamingSupported,
   };
 }
@@ -174,6 +178,30 @@ async function fetchRegion(region: string): Promise<RegionData> {
   return { onDemand: onDemandModels, regional, global };
 }
 
+// Recursively sort object keys so JSON.stringify produces byte-stable
+// output across runs. Object property iteration order in JS depends on
+// insertion order, so any change in the producer code (ordering of fetch
+// results, Map iteration, etc.) silently shuffles keys in the serialised
+// output and creates spurious git diffs. With this helper the diff signal
+// is meaningful: a non-zero diff means model availability genuinely
+// changed (or generatedAt advanced).
+function stableStringify(value: unknown): string {
+  const sortKeys = (v: unknown): unknown => {
+    if (Array.isArray(v)) return v.map(sortKeys);
+    if (v && typeof v === "object") {
+      const o = v as Record<string, unknown>;
+      return Object.keys(o)
+        .sort()
+        .reduce<Record<string, unknown>>((acc, k) => {
+          acc[k] = sortKeys(o[k]);
+          return acc;
+        }, {});
+    }
+    return v;
+  };
+  return JSON.stringify(sortKeys(value), null, 2) + "\n";
+}
+
 async function main() {
   const output: Output = {
     generatedAt: new Date().toISOString(),
@@ -212,7 +240,7 @@ async function main() {
 
   const outPath = resolve(import.meta.dir, "..", "public", "data.json");
   await mkdir(dirname(outPath), { recursive: true });
-  await writeFile(outPath, JSON.stringify(output, null, 2));
+  await writeFile(outPath, stableStringify(output));
 
   const ok = Object.keys(output.regions).length;
   const failed = Object.keys(output.errors).length;


### PR DESCRIPTION
## Summary

Two small substrate changes that prepare `bedrock-region-viewer` for a future git-history-as-time-series dashboard (mirroring `sjramblings/aws-ip-ranges`) without committing to building it yet.

## 1. fetch-data.ts: byte-stable serialisation

- Added `stableStringify()` that recursively sorts object keys before `JSON.stringify`. JS object iteration is insertion-order, so any future change to the producer (different fetch ordering, Map iteration, etc.) silently shuffles keys in the output and creates spurious git diffs.
- Sorted modality + inferenceType arrays inside `mapModel()`. AWS does not guarantee order; unsorted arrays produce shuffle-only diffs.

**Verified locally:** two consecutive runs of `bun run fetch` produce byte-identical output except for the `generatedAt` timestamp:

```diff
37c37
<   "generatedAt": "2026-05-07T13:29:00.887Z",
---
>   "generatedAt": "2026-05-07T13:29:01.003Z",
```

The semantic diff in `scripts/diff-data.ts` (set-based on `modelId`/`profileId`) already filters out shuffle-only changes from creating commits. This change makes the underlying file byte-stable as well, so when commits do fire (real model availability change), the git diff signal is meaningful to humans and to any future commit-by-commit extractor.

## 2. refresh-data.yml: history-depth trigger

- Added a new step at the end of the refresh job (`if: always()`) that counts commits to `public/data.json` on `origin/main` and writes the number to `GITHUB_STEP_SUMMARY`.
- When count `>=` 90 (~3 months of nightly history), emits a `::notice::` alert. 90 commits is roughly the point at which a time-series dashboard becomes worth building — enough first-appearance events, growth signals, and regional-profile launches to plot.

Until the trigger fires, the snapshot UI continues doing its job and git history quietly accrues the data.

## Risk

Minimal.

- The serialisation change preserves all data; only ordering changes. The first commit after merge will contain a one-shot whole-file shuffle as the existing `data.json` re-sorts. After that, diffs converge to model-availability deltas only.
- The history-depth step is informational (`if: always()`, no `exit 1`); it cannot fail the workflow.

## Verification

- [x] `bun run fetch` produces byte-stable output across runs (only `generatedAt` differs)
- [x] Top-level keys sorted alphabetically (`errors` < `generatedAt` < `regions`)
- [x] Modality arrays sorted (verified in mapModel output)
- [x] Workflow YAML parses (no syntax errors)
- [ ] First post-merge nightly run will produce a single big-diff commit as data.json re-sorts; all subsequent runs converge to clean diffs (maintainer can confirm)