### PR TITLE
feat: globe view — Bedrock regions coloured by inference-profile geography

### DIFF
--- a/public/globe.html
+++ b/public/globe.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Bedrock Globe — Inference-Profile Geography</title>
+    <meta name="description" content="AWS Bedrock model availability on a globe, coloured by inference-profile geographic membership." />
+    <link rel="stylesheet" href="styles.css" />
+    <script src="https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/topojson-client@3"></script>
+  </head>
+  <body class="globe-page">
+    <header class="top">
+      <div class="top-row">
+        <h1>Bedrock Globe</h1>
+        <nav class="globe-nav">
+          <a href="index.html">Region viewer →</a>
+          <button id="theme-toggle" type="button" aria-label="Toggle dark mode">🌓</button>
+        </nav>
+      </div>
+      <p class="meta">
+        <span id="meta-generated">Loading…</span>
+        <span class="sep">·</span>
+        <span>Drag to rotate · click a pin for detail</span>
+      </p>
+      <div id="error-banner" class="banner hidden"></div>
+    </header>
+
+    <main class="globe-main">
+      <section class="globe-stage">
+        <div id="globe-container"></div>
+        <aside id="globe-detail" class="globe-detail hidden">
+          <button class="globe-detail-close" type="button" aria-label="Close">×</button>
+          <h2 id="detail-region" class="detail-region">—</h2>
+          <p id="detail-summary" class="detail-summary"></p>
+          <ul id="detail-profiles" class="detail-profiles"></ul>
+        </aside>
+      </section>
+
+      <section class="globe-legend" aria-label="Legend">
+        <h3>Inference-profile membership</h3>
+        <ul>
+          <li><span class="swatch" data-geo="us"></span>US (us.* profiles)</li>
+          <li><span class="swatch" data-geo="eu"></span>EU (eu.* profiles)</li>
+          <li><span class="swatch" data-geo="apac"></span>APAC (apac.* profiles)</li>
+          <li><span class="swatch" data-geo="au"></span>Australia (au.* profiles)</li>
+          <li><span class="swatch" data-geo="ca"></span>Canada (ca.* profiles)</li>
+          <li><span class="swatch" data-geo="jp"></span>Japan (jp.* profiles)</li>
+          <li><span class="swatch" data-geo="us-gov"></span>GovCloud (us-gov.* profiles)</li>
+          <li><span class="swatch" data-geo="multi"></span>Multiple geos</li>
+          <li><span class="swatch" data-geo="ondemand"></span>On-demand only — no profile</li>
+          <li><span class="swatch swatch-ring" data-geo="global"></span>Ring: also in a global.* profile</li>
+        </ul>
+        <p class="legend-note">Pin size scales with on-demand model count.</p>
+      </section>
+    </main>
+
+    <script src="globe.js"></script>
+  </body>
+</html>

--- a/public/globe.js
+++ b/public/globe.js
@@ -1,0 +1,397 @@
+// Bedrock Globe — vanilla-JS port of aws-ip-ranges Globe.tsx, adapted for
+// inference-profile geography. No build step. D3 + topojson loaded from CDN
+// (see globe.html).
+
+(function () {
+  "use strict";
+
+  // AWS region → [lng, lat] city centroids (D3/GeoJSON convention).
+  // Mirrors sjramblings/aws-ip-ranges site/src/globe/region-coords.ts so the
+  // two dashboards stay coordinate-consistent.
+  const REGION_COORDS = {
+    "us-east-1":      [-77.46, 38.95],
+    "us-east-2":      [-83.00, 39.96],
+    "us-west-1":      [-121.96, 37.35],
+    "us-west-2":      [-119.70, 45.84],
+    "us-gov-east-1":  [-77.46, 38.95],
+    "us-gov-west-1":  [-119.70, 45.84],
+    "ca-central-1":   [-73.57, 45.50],
+    "ca-west-1":      [-114.07, 51.04],
+    "mx-central-1":   [-100.39, 20.59],
+    "sa-east-1":      [-46.63, -23.55],
+    "eu-west-1":      [-6.27, 53.35],
+    "eu-west-2":      [-0.13, 51.51],
+    "eu-west-3":      [2.35, 48.86],
+    "eu-central-1":   [8.68, 50.11],
+    "eu-central-2":   [8.55, 47.37],
+    "eu-north-1":     [18.07, 59.33],
+    "eu-south-1":     [9.19, 45.46],
+    "eu-south-2":     [-0.88, 41.66],
+    "me-central-1":   [54.37, 24.47],
+    "me-south-1":     [50.55, 26.07],
+    "il-central-1":   [34.78, 32.08],
+    "af-south-1":     [18.42, -33.92],
+    "ap-east-1":      [114.17, 22.32],
+    "ap-east-2":      [121.56, 25.04],
+    "ap-south-1":     [72.88, 19.08],
+    "ap-south-2":     [78.49, 17.39],
+    "ap-northeast-1": [139.76, 35.68],
+    "ap-northeast-2": [126.98, 37.57],
+    "ap-northeast-3": [135.50, 34.69],
+    "ap-southeast-1": [103.82, 1.35],
+    "ap-southeast-2": [151.21, -33.87],
+    "ap-southeast-3": [106.85, -6.21],
+    "ap-southeast-4": [144.96, -37.81],
+    "ap-southeast-5": [101.69, 3.14],
+    "ap-southeast-7": [100.50, 13.76],
+  };
+
+  const GEO_COLORS = {
+    us:        "#FF9900",
+    eu:        "#3B82F6",
+    apac:      "#22D3D9",
+    au:        "#84CC16",
+    ca:        "#EF4444",
+    jp:        "#EC4899",
+    "us-gov":  "#A78BFA",
+    multi:     "#F59E0B",
+    ondemand:  "#64748B",
+    global:    "#0FB5BA",
+  };
+
+  const TOPOLOGY_URL = "https://unpkg.com/world-atlas@2/land-110m.json";
+
+  // ── DOM refs ──
+  const container = document.getElementById("globe-container");
+  const errorBanner = document.getElementById("error-banner");
+  const metaEl = document.getElementById("meta-generated");
+  const detailEl = document.getElementById("globe-detail");
+  const detailRegion = document.getElementById("detail-region");
+  const detailSummary = document.getElementById("detail-summary");
+  const detailProfiles = document.getElementById("detail-profiles");
+  const detailClose = document.querySelector(".globe-detail-close");
+  const themeToggle = document.getElementById("theme-toggle");
+
+  // ── State ──
+  let topology = null;
+  let dots = [];
+  let rotation = [20, -10];
+  let selected = null;
+  let svgEl = null;
+  let projection = null;
+  let path = null;
+  let size = { w: 760, h: 760 };
+
+  // Persist + restore theme
+  const storedTheme = localStorage.getItem("bedrock-theme");
+  if (storedTheme) document.documentElement.dataset.theme = storedTheme;
+  themeToggle?.addEventListener("click", () => {
+    const next = (document.documentElement.dataset.theme === "dark") ? "light" : "dark";
+    document.documentElement.dataset.theme = next;
+    localStorage.setItem("bedrock-theme", next);
+  });
+
+  detailClose?.addEventListener("click", () => {
+    selected = null;
+    detailEl.classList.add("hidden");
+    redraw();
+  });
+
+  // ── Boot ──
+  Promise.all([
+    fetch("data.json").then((r) => r.json()).catch((e) => {
+      showError("Failed to load data.json — run `bun run fetch` first. " + e.message);
+      return null;
+    }),
+    fetch(TOPOLOGY_URL).then((r) => r.ok ? r.json() : null).catch(() => null),
+  ]).then(([data, topo]) => {
+    if (!data) return;
+    topology = topo;
+    metaEl.textContent = data.generatedAt
+      ? `Snapshot: ${data.generatedAt}`
+      : "Snapshot: unknown";
+    dots = buildDots(data);
+    initGlobe();
+    redraw();
+  });
+
+  function showError(msg) {
+    errorBanner.textContent = msg;
+    errorBanner.classList.remove("hidden");
+  }
+
+  // ── Data shaping ──
+
+  function buildDots(data) {
+    const out = [];
+    const regions = data.regions || {};
+    for (const [region, rd] of Object.entries(regions)) {
+      const coord = REGION_COORDS[region];
+      if (!coord) continue;
+      const onDemandCount = (rd.onDemand || []).length;
+      // Geo memberships: which geo prefixes have profiles routing through this region
+      const geos = new Set();
+      for (const p of (rd.regional || [])) {
+        if (p.geo) geos.add(p.geo);
+      }
+      const inGlobal = (rd.global || []).length > 0;
+      const geoList = [...geos].sort();
+      let colorKey;
+      if (geoList.length === 0) colorKey = "ondemand";
+      else if (geoList.length === 1) colorKey = geoList[0];
+      else colorKey = "multi";
+
+      out.push({
+        region,
+        lng: coord[0],
+        lat: coord[1],
+        onDemandCount,
+        regional: rd.regional || [],
+        global: rd.global || [],
+        geos: geoList,
+        inGlobal,
+        colorKey,
+      });
+    }
+    return out;
+  }
+
+  // ── Globe init ──
+
+  function initGlobe() {
+    container.innerHTML = "";
+    const w = Math.min(container.clientWidth || 760, 760);
+    size = { w, h: w };
+
+    svgEl = d3.select(container)
+      .append("svg")
+      .attr("width", size.w)
+      .attr("height", size.h)
+      .attr("viewBox", `0 0 ${size.w} ${size.h}`)
+      .style("display", "block")
+      .style("margin", "0 auto")
+      .style("touch-action", "none")
+      .style("cursor", "grab");
+
+    // Defs for glow + halo gradients
+    const defs = svgEl.append("defs");
+    const haloGrad = defs.append("radialGradient")
+      .attr("id", "globe-halo")
+      .attr("cx", "50%").attr("cy", "50%").attr("r", "50%");
+    haloGrad.append("stop").attr("offset", "92%").attr("stop-color", "#FF9900").attr("stop-opacity", 0);
+    haloGrad.append("stop").attr("offset", "100%").attr("stop-color", "#FF9900").attr("stop-opacity", 0.18);
+
+    const shadeGrad = defs.append("radialGradient")
+      .attr("id", "globe-shade")
+      .attr("cx", "35%").attr("cy", "35%").attr("r", "65%");
+    shadeGrad.append("stop").attr("offset", "0%").attr("stop-color", "#0F141A").attr("stop-opacity", 0);
+    shadeGrad.append("stop").attr("offset", "70%").attr("stop-color", "#0B0F14").attr("stop-opacity", 0.65);
+    shadeGrad.append("stop").attr("offset", "100%").attr("stop-color", "#000").attr("stop-opacity", 0.95);
+
+    defs.append("filter").attr("id", "dot-glow")
+      .attr("x", "-50%").attr("y", "-50%").attr("width", "200%").attr("height", "200%")
+      .append("feGaussianBlur").attr("stdDeviation", 2);
+
+    // Halo
+    svgEl.append("circle")
+      .attr("class", "halo")
+      .attr("cx", size.w / 2).attr("cy", size.h / 2)
+      .attr("r", (size.w / 2) - 4)
+      .attr("fill", "url(#globe-halo)");
+
+    // Sphere, graticule, land, dots groups (drawn order matters)
+    svgEl.append("path").attr("class", "sphere").attr("fill", "#0F141A").attr("stroke", "rgba(58,70,84,0.5)").attr("stroke-width", 1);
+    svgEl.append("path").attr("class", "graticule").attr("fill", "none").attr("stroke", "rgba(58,70,84,0.35)").attr("stroke-width", 0.5);
+    svgEl.append("path").attr("class", "land").attr("fill", "#1E2733").attr("stroke", "rgba(15,181,186,0.35)").attr("stroke-width", 0.5);
+    svgEl.append("path").attr("class", "shade").attr("fill", "url(#globe-shade)").attr("pointer-events", "none");
+    svgEl.append("g").attr("class", "dots");
+
+    // Drag to rotate — sensitivity 0.4, accumulate dx/dy (NOT absolute x/y) to
+    // avoid the drag-start jump (codex P1 noted in aws-ip-ranges PR #5).
+    const sensitivity = 0.4;
+    svgEl.call(d3.drag()
+      .on("start", () => svgEl.style("cursor", "grabbing"))
+      .on("drag", (ev) => {
+        rotation = [
+          rotation[0] + ev.dx * sensitivity,
+          Math.max(-90, Math.min(90, rotation[1] - ev.dy * sensitivity)),
+        ];
+        redraw();
+      })
+      .on("end", () => svgEl.style("cursor", "grab")));
+  }
+
+  function redraw() {
+    if (!svgEl) return;
+
+    projection = d3.geoOrthographic()
+      .scale(size.w / 2 - 12)
+      .translate([size.w / 2, size.h / 2])
+      .clipAngle(90)
+      .rotate([rotation[0], rotation[1]]);
+    path = d3.geoPath(projection);
+
+    const sphereD = path({ type: "Sphere" });
+    svgEl.select(".sphere").attr("d", sphereD);
+    svgEl.select(".shade").attr("d", sphereD);
+    svgEl.select(".graticule").attr("d", path(d3.geoGraticule10()));
+
+    if (topology && topology.objects && topology.objects.land) {
+      const land = topojson.feature(topology, topology.objects.land);
+      svgEl.select(".land").attr("d", path(land));
+    }
+
+    // Sqrt scale: pin radius from on-demand count
+    const maxCount = dots.reduce((m, d) => Math.max(m, d.onDemandCount), 1);
+    const scale = d3.scaleSqrt().domain([0, maxCount]).range([2.5, 12]);
+
+    const g = svgEl.select(".dots");
+    g.selectAll("g.dot").remove();
+
+    for (const d of dots) {
+      const projected = projection([d.lng, d.lat]);
+      if (!projected) continue; // far hemisphere — clipped
+      const [px, py] = projected;
+      const r = scale(d.onDemandCount);
+      const sel = selected === d.region;
+      const color = GEO_COLORS[d.colorKey] || GEO_COLORS.ondemand;
+
+      const dot = g.append("g")
+        .attr("class", "dot")
+        .attr("transform", `translate(${px},${py})`)
+        .style("cursor", "pointer")
+        .on("click", () => {
+          selected = (sel ? null : d.region);
+          if (selected) {
+            animateRotateTo(d.lng, d.lat);
+            showDetail(d);
+          } else {
+            detailEl.classList.add("hidden");
+          }
+          redraw();
+        })
+        .on("mouseenter", () => showTooltip(d, px, py))
+        .on("mouseleave", hideTooltip);
+
+      // Glow halo behind pin
+      dot.append("circle")
+        .attr("r", r * 1.6).attr("fill", color)
+        .attr("opacity", sel ? 0.3 : 0.18)
+        .attr("filter", "url(#dot-glow)");
+      // Main pin
+      dot.append("circle")
+        .attr("r", r).attr("fill", color)
+        .attr("opacity", 0.95)
+        .attr("stroke", "#0B0F14")
+        .attr("stroke-width", sel ? 2 : 1);
+      // global ring overlay
+      if (d.inGlobal) {
+        dot.append("circle")
+          .attr("r", r + 3).attr("fill", "none")
+          .attr("stroke", GEO_COLORS.global).attr("stroke-width", 1.4)
+          .attr("opacity", 0.85);
+      }
+      // Selection pulse
+      if (sel) {
+        const pulse = dot.append("circle")
+          .attr("r", r + 6).attr("fill", "none")
+          .attr("stroke", color).attr("stroke-width", 1.2).attr("opacity", 0.6);
+        pulse.append("animate")
+          .attr("attributeName", "r")
+          .attr("values", `${r + 4};${r + 14};${r + 4}`)
+          .attr("dur", "2.4s").attr("repeatCount", "indefinite");
+        pulse.append("animate")
+          .attr("attributeName", "opacity")
+          .attr("values", "0.7;0;0.7")
+          .attr("dur", "2.4s").attr("repeatCount", "indefinite");
+      }
+    }
+  }
+
+  // ── Animation: ease rotation to target lng/lat ──
+  function animateRotateTo(lng, lat) {
+    const target = [-lng, -lat];
+    const start = performance.now();
+    const dur = 700;
+    const [l0, p0] = rotation;
+    function tick(now) {
+      const t = Math.min(1, (now - start) / dur);
+      const eased = 1 - Math.pow(1 - t, 3);
+      rotation = [
+        l0 + (target[0] - l0) * eased,
+        p0 + (target[1] - p0) * eased,
+      ];
+      redraw();
+      if (t < 1) requestAnimationFrame(tick);
+    }
+    requestAnimationFrame(tick);
+  }
+
+  // ── Tooltip ──
+  let tooltipEl = null;
+  function showTooltip(d, px, py) {
+    hideTooltip();
+    tooltipEl = document.createElement("div");
+    tooltipEl.className = "globe-tooltip";
+    const geoLabel = d.geos.length === 0 ? "(on-demand only)"
+      : d.geos.length === 1 ? d.geos[0]
+      : `${d.geos.length} geos: ${d.geos.join(", ")}`;
+    const globalLabel = d.inGlobal ? ` · in global.*` : "";
+    tooltipEl.innerHTML = `
+      <div class="tt-region">${escapeHtml(d.region)}</div>
+      <div class="tt-stat"><strong>${d.onDemandCount}</strong> on-demand model${d.onDemandCount === 1 ? "" : "s"}</div>
+      <div class="tt-stat"><strong>${d.regional.length}</strong> regional profile${d.regional.length === 1 ? "" : "s"}${globalLabel}</div>
+      <div class="tt-geo">${escapeHtml(geoLabel)}</div>
+    `;
+    const rect = container.getBoundingClientRect();
+    tooltipEl.style.left = Math.min(size.w - 200, Math.max(0, px + 14)) + "px";
+    tooltipEl.style.top = Math.max(0, py - 36) + "px";
+    container.appendChild(tooltipEl);
+  }
+  function hideTooltip() {
+    if (tooltipEl) { tooltipEl.remove(); tooltipEl = null; }
+  }
+
+  // ── Detail card ──
+  function showDetail(d) {
+    detailEl.classList.remove("hidden");
+    detailRegion.textContent = d.region;
+    const summary = [
+      `${d.onDemandCount} on-demand model${d.onDemandCount === 1 ? "" : "s"}`,
+      `${d.regional.length} regional profile${d.regional.length === 1 ? "" : "s"}`,
+      d.inGlobal ? `${d.global.length} global profile${d.global.length === 1 ? "" : "s"}` : null,
+    ].filter(Boolean).join(" · ");
+    detailSummary.textContent = summary;
+
+    detailProfiles.innerHTML = "";
+    const allProfiles = [
+      ...d.regional.map((p) => ({ ...p, kind: "regional" })),
+      ...d.global.map((p) => ({ ...p, kind: "global" })),
+    ];
+    if (allProfiles.length === 0) {
+      const li = document.createElement("li");
+      li.className = "profile-empty";
+      li.textContent = "No inference profiles route through this region.";
+      detailProfiles.appendChild(li);
+      return;
+    }
+    allProfiles.sort((a, b) => a.profileId.localeCompare(b.profileId));
+    for (const p of allProfiles) {
+      const li = document.createElement("li");
+      li.innerHTML = `
+        <code>${escapeHtml(p.profileId)}</code>
+        <span class="profile-kind">${p.kind}${p.geo ? ` · ${escapeHtml(p.geo)}` : ""}</span>
+        <span class="profile-models">${p.models.length} model${p.models.length === 1 ? "" : "s"}</span>
+      `;
+      detailProfiles.appendChild(li);
+    }
+  }
+
+  function escapeHtml(s) {
+    return String(s)
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;");
+  }
+})();

--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,10 @@
     <header class="top">
       <div class="top-row">
         <h1>Bedrock Models by Region</h1>
-        <button id="theme-toggle" type="button" aria-label="Toggle dark mode">🌓</button>
+        <nav class="top-nav">
+          <a href="globe.html">Globe view →</a>
+          <button id="theme-toggle" type="button" aria-label="Toggle dark mode">🌓</button>
+        </nav>
       </div>
       <div class="controls">
         <label class="control">

--- a/public/styles.css
+++ b/public/styles.css
@@ -313,3 +313,150 @@ tbody tr:hover { background: color-mix(in srgb, var(--accent) 6%, transparent); 
 }
 
 .toast.show { opacity: 1; }
+
+.top-nav { display: flex; gap: 12px; align-items: center; }
+.top-nav a { color: var(--accent); text-decoration: none; font-size: 14px; }
+.top-nav a:hover { text-decoration: underline; }
+
+/* ─── Globe page ─────────────────────────────────────────────────────────── */
+
+.globe-page main.globe-main {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 280px;
+  gap: 24px;
+  padding: 16px;
+  align-items: start;
+}
+
+@media (max-width: 900px) {
+  .globe-page main.globe-main { grid-template-columns: 1fr; }
+}
+
+.globe-nav { display: flex; gap: 12px; align-items: center; }
+.globe-nav a { color: var(--accent); text-decoration: none; font-size: 14px; }
+.globe-nav a:hover { text-decoration: underline; }
+
+.globe-stage {
+  position: relative;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+  min-height: 500px;
+}
+
+#globe-container {
+  position: relative;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  user-select: none;
+}
+
+.globe-tooltip {
+  position: absolute;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px 10px;
+  font-size: 12px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.18);
+  pointer-events: none;
+  min-width: 160px;
+  z-index: 10;
+}
+
+.globe-tooltip .tt-region { font-family: var(--mono); color: var(--accent); font-weight: 600; }
+.globe-tooltip .tt-stat { margin-top: 2px; }
+.globe-tooltip .tt-geo { margin-top: 4px; color: var(--muted); font-size: 11px; }
+
+.globe-detail {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  width: 260px;
+  max-height: calc(100% - 24px);
+  overflow-y: auto;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px 14px;
+  box-shadow: 0 6px 20px rgba(0,0,0,0.22);
+  font-size: 13px;
+}
+
+.globe-detail.hidden { display: none; }
+
+.globe-detail-close {
+  position: absolute;
+  top: 6px;
+  right: 8px;
+  background: transparent;
+  border: 0;
+  font-size: 20px;
+  line-height: 1;
+  cursor: pointer;
+  color: var(--muted);
+}
+
+.detail-region { margin: 0 24px 4px 0; font-family: var(--mono); font-size: 14px; color: var(--accent); }
+.detail-summary { margin: 0 0 10px; color: var(--muted); font-size: 12px; }
+
+.detail-profiles { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 6px; }
+.detail-profiles li {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  padding: 6px 8px;
+  font-size: 12px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 4px 8px;
+  align-items: baseline;
+}
+.detail-profiles code { font-family: var(--mono); font-size: 11px; word-break: break-all; }
+.detail-profiles .profile-kind { color: var(--muted); font-size: 11px; grid-column: 1; }
+.detail-profiles .profile-models { color: var(--muted); font-size: 11px; grid-column: 2; grid-row: 1 / span 2; align-self: center; white-space: nowrap; }
+.detail-profiles .profile-empty { color: var(--muted); font-style: italic; grid-template-columns: 1fr; }
+
+.globe-legend {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 14px 16px;
+  font-size: 13px;
+}
+.globe-legend h3 { margin: 0 0 10px; font-size: 13px; font-weight: 600; }
+.globe-legend ul { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 6px; }
+.globe-legend li { display: flex; align-items: center; gap: 8px; }
+
+.swatch {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.swatch[data-geo="us"]       { background: #FF9900; }
+.swatch[data-geo="eu"]       { background: #3B82F6; }
+.swatch[data-geo="apac"]     { background: #22D3D9; }
+.swatch[data-geo="au"]       { background: #84CC16; }
+.swatch[data-geo="ca"]       { background: #EF4444; }
+.swatch[data-geo="jp"]       { background: #EC4899; }
+.swatch[data-geo="us-gov"]   { background: #A78BFA; }
+.swatch[data-geo="multi"]    { background: #F59E0B; }
+.swatch[data-geo="ondemand"] { background: #64748B; }
+
+.swatch-ring[data-geo="global"] {
+  background: transparent;
+  border: 2px solid #0FB5BA;
+  width: 12px;
+  height: 12px;
+  box-sizing: border-box;
+}
+
+.legend-note {
+  margin: 10px 0 0;
+  color: var(--muted);
+  font-size: 11px;
+}


### PR DESCRIPTION
## Summary

A new `globe.html` page that visualises AWS Bedrock model availability on a draggable D3 orthographic globe. Pins are coloured by which geographic inference-profile collection each region participates in, sized by on-demand model count.

**Why this and not the time-series view:** the time-series story (when did model X land in region Y, growth curves, first-appearance events) needs ~3 months of git history before it's interesting. Geography is a snapshot question — purely uses today's `data.json`. We can ship it now while the reference code is fresh, and the same component becomes the time-series substrate later.

The companion PR #17 adds the 90-commit trigger that will signal when to layer the time dimension on top.

## What it shows

- Every supported AWS region rendered as a pin at its city centroid
- Pin **colour** by membership in regional inference profiles:
  - `us` orange, `eu` blue, `apac` cyan, `au` lime, `ca` red, `jp` pink, `us-gov` purple
  - amber for regions in **multiple** geo collections
  - grey for **on-demand-only** regions (no profile membership)
  - bright cyan **ring overlay** when the region also participates in a `global.*` profile
- Pin **size** `sqrt`-scaled by on-demand model count (range 2.5–12px)
- **Drag** to rotate the globe smoothly (sensitivity 0.4, accumulates `dx`/`dy` per event — avoids the drag-start jump pattern from aws-ip-ranges PR #5)
- **Click** a pin to select it: auto-rotate animation easing toward the region centroid + side detail card listing all routing profiles
- **Hover** tooltip with region name, on-demand count, profile count, geo memberships
- Far-hemisphere pins clipped via `clipAngle(90)`
- Sidebar legend explains the nine colour bands + the global-ring convention

## Stack choices (intentional)

- **Vanilla JS, no React, no Vite, no build step** — matches the existing 'dependency-light' ethos of the snapshot UI. Adding a React+Vite stack for one new page would be a meaningful architecture shift; `bun x serve public` continues to work as-is
- D3 + topojson-client loaded from CDN at runtime (`cdn.jsdelivr.net`)
- World land topology fetched from `unpkg.com/world-atlas@2/land-110m.json`. If it fails (CDN down, offline), the globe gracefully renders sphere + graticule + pins only
- Region coordinates lifted verbatim from `sjramblings/aws-ip-ranges/site/src/globe/region-coords.ts` so the two dashboards stay coordinate-consistent
- Reuses existing `styles.css` with ~147 appended lines; theme toggle wired to the same `localStorage` key (`bedrock-theme`) as the snapshot UI

## Reference scaffold

D3 logic (drag accumulation, sqrt scale, halo gradient, clipAngle handling, ease-cubed rotation animation) ported from the React component at `sjramblings/aws-ip-ranges/site/src/globe/Globe.tsx` — translated to vanilla JS for this repo's stack.

## Files

| File | Change |
|---|---|
| `public/globe.html` | NEW — page markup, CDN script tags, legend, detail card |
| `public/globe.js` | NEW — D3 globe + colour-by-geo + drag + tooltip + detail card (vanilla, ~395 lines) |
| `public/styles.css` | +147 — globe page styles (legend, tooltip, detail card, swatches) |
| `public/index.html` | +3 — nav link to `/globe.html` |

## Local verification

- `bun x serve public -l 8088` serves all four files (200 OK on globe.html, globe.js, data.json)
- `globe.js` parses cleanly (Node `new Function(src)` syntax check)

## Remaining maintainer verification before merge

- [ ] Visual: globe renders with land outlines (CDN topology loads)
- [ ] Drag rotates smoothly, no jump on drag-start
- [ ] Click pin → globe rotates, detail card appears with profiles listed
- [ ] Hover tooltip positioned correctly, doesn't overflow on edge regions
- [ ] Legend swatches match actual pin colours on the globe
- [ ] Mobile/narrow viewport: layout collapses to single column at `max-width: 900px`
- [ ] Theme toggle: dark + light both readable
- [ ] Browser console: zero errors

## Out of scope (deliberate)

- Time-series dimension — defer until 90-commit threshold (PR #17)
- Filter-by-profile-collection click on legend items — follow-up
- Mobile-friendly touch drag tuning — current sensitivity is desktop-tuned
- Topology file bundled into repo (currently CDN-fetched) — follow-up if Amplify deploy benefits from local copy