### PR TITLE
feat(ci): deploy site/ to GitHub Pages — Amplify left untouched

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,96 @@
+name: Deploy site to GitHub Pages
+
+# Mirrors sjramblings/aws-ip-ranges/.github/workflows/build-site.yml
+# behaviour: build the Vite site and publish to Pages on every push to main
+# that affects the site, plus PR builds (verify-only) and manual dispatch.
+#
+# This workflow is independent from `deploy-amplify.yml`, which continues to
+# deploy the legacy vanilla `public/` site to AWS Amplify. Both deploys
+# coexist:
+#   * Amplify  → awshostedmodels.sjramblings.io (legacy public/)
+#   * Pages    → sjramblings.github.io/bedrock-region-viewer (new site/)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "site/**"
+      - "public/data.json"
+      - ".github/workflows/deploy-pages.yml"
+  pull_request:
+    paths:
+      - "site/**"
+      - "public/data.json"
+      - ".github/workflows/deploy-pages.yml"
+  # When the nightly Refresh Bedrock catalog workflow auto-merges its
+  # data PR, GitHub suppresses the resulting push event from triggering
+  # other workflows. This workflow_run trigger catches that merge so
+  # fresh data redeploys to Pages without manual intervention.
+  workflow_run:
+    workflows: ["Refresh Bedrock catalog"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, but don't cancel in-progress
+# runs — we want the latest data to land even if a build is mid-flight.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build site
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      # The repo ships site/public/data.json as a symlink to the canonical
+      # public/data.json so the dev server reads the nightly snapshot
+      # without duplicating the file. CI checkouts on Linux preserve
+      # symlinks, but we replace it with a real copy here so the Vite
+      # build step is robust to any future change in checkout behaviour
+      # and so the artifact uploaded to Pages contains the data inline.
+      - name: Materialise data.json
+        run: |
+          rm -f site/public/data.json
+          cp public/data.json site/public/data.json
+
+      - name: Install site dependencies
+        working-directory: ./site
+        run: bun install --frozen-lockfile
+
+      - name: Build site
+        working-directory: ./site
+        run: bun run build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./site/dist
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    # Skip deployment on PR builds — PRs verify the build only, never overwrite production.
+    if: github.event_name != 'pull_request'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -1,13 +1,17 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
-// Vite config for the aligned-port. Differences from the aws-ip-ranges
-// reference:
-//   * No `base:` override — this site deploys at the root of
-//     awshostedmodels.sjramblings.io, not under a /aws-ip-ranges/ subpath
+// Vite config for the aligned-port. Mirrors sjramblings/aws-ip-ranges
+// configuration:
+//   * `base: "/bedrock-region-viewer/"` — this site deploys to GitHub
+//     Pages at sjramblings.github.io/bedrock-region-viewer/, so all
+//     asset URLs need that prefix. (Matches aws-ip-ranges' `/aws-ip-ranges/`
+//     base.) The legacy Amplify deploy at awshostedmodels.sjramblings.io
+//     continues to serve the vanilla `public/` site, untouched.
 //   * Single entry — no separate globe.html; the Globe is rendered by the
 //     main App alongside the (forthcoming) Hero / RegionAtlas / etc.
 export default defineConfig({
+  base: "/bedrock-region-viewer/",
   plugins: [react()],
   build: {
     target: "es2022",


### PR DESCRIPTION
## Summary

Adds a GitHub Pages deploy workflow modelled on `sjramblings/aws-ip-ranges/.github/workflows/build-site.yml` so the React site (introduced in #19) publishes to **https://sjramblings.github.io/bedrock-region-viewer/** on every push to main that touches `site/`, the snapshot, or the workflow itself.

**Amplify is intentionally left alone.** Its existing path filter (`paths: ['public/**', ...]`) already excludes `site/`, so the legacy vanilla site at `awshostedmodels.sjramblings.io` continues to deploy from `public/` unchanged. After this lands the repo runs **two coexisting deploys**:

| Surface | URL | Source | Workflow |
|---|---|---|---|
| Amplify *(unchanged)* | `awshostedmodels.sjramblings.io` | `public/` (legacy vanilla) | `deploy-amplify.yml` |
| **Pages** *(new)* | `sjramblings.github.io/bedrock-region-viewer/` | `site/dist/` (new React app) | `deploy-pages.yml` |

## Changes

### 1. `.github/workflows/deploy-pages.yml` *(new — 96 lines)*

Triggers:
- `push` to `main` with paths `site/`, `public/data.json`, this workflow
- `pull_request` with same paths (verify-only — does NOT deploy)
- `workflow_run` on "Refresh Bedrock catalog" completion — catches the case where the nightly data PR auto-merges and GitHub suppresses the resulting push event from re-triggering (same pattern Amplify already uses)
- `workflow_dispatch` for manual reruns

Build job:
1. `setup-bun`
2. **Materialise `data.json`** — replace the symlink at `site/public/data.json` with a real copy from `public/data.json`. CI checkouts on Linux preserve symlinks, but a real copy is more robust to checkout-config drift and ensures the Pages artifact contains the data inline
3. `bun install --frozen-lockfile` in `./site`
4. `bun run build` in `./site`
5. `upload-pages-artifact` from `./site/dist`

Deploy job: `actions/deploy-pages@v4`, skipped on PR builds.

### 2. `site/vite.config.ts` *(modified — 12 lines)*

Added `base: '/bedrock-region-viewer/'`. Without this, the built `index.html` references assets at `/assets/...` — fine for root-domain deploys, broken for the GitHub Pages subpath. Mirrors the `/aws-ip-ranges/` base in the upstream reference.

## Build verification

```bash
$ cd site && bun run build
✓ tsc -b: no errors
✓ 313 modules transformed
✓ built in 1.08s

$ grep 'src=' dist/index.html
<script type="module" crossorigin src="/bedrock-region-viewer/assets/index-CA90Lynb.js"></script>
```

Asset URLs are correctly prefixed with the Pages subpath.

## What this does NOT do

- Doesn't touch `deploy-amplify.yml` — Amplify pipeline unchanged
- Doesn't remove anything from `public/` — legacy vanilla site stays
- Doesn't change CNAME or DNS for the Amplify domain
- Doesn't merge the substrate-fix or scaffold PRs (#17 and #19 are already merged)

## Maintainer testing

- [ ] PR build (this PR): the build job should succeed without deploying. The `deploy` job should be skipped (PR event)
- [ ] Once merged: push to main triggers full build + deploy; site visible at `https://sjramblings.github.io/bedrock-region-viewer/`
- [ ] Verify globe renders (drag, hover, click) on the deployed page
- [ ] Verify `/data.json` loads (Network tab) — should hit `/bedrock-region-viewer/data.json`
- [ ] Verify Amplify deploy at `awshostedmodels.sjramblings.io` still serves the legacy vanilla site (no regression)