### PR TITLE
feat(ci): publish GitHub Release on data change instead of opening an Issue

### DIFF
--- a/.github/workflows/refresh-data.yml
+++ b/.github/workflows/refresh-data.yml
@@ -9,7 +9,6 @@ permissions:
   id-token: write
   contents: write
   pull-requests: write
-  issues: write
 
 concurrency:
   group: refresh-data
@@ -81,7 +80,7 @@ jobs:
             echo "No model availability changes." >> "$GITHUB_STEP_SUMMARY"
           fi
 
-      - name: Open PR and create tracking issue
+      - name: Open PR for nightly data refresh
         if: steps.diff.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -114,23 +113,13 @@ jobs:
           git commit -m "chore(data): nightly Bedrock catalog refresh ${DATE}"
           git push -u origin "$BRANCH"
 
-          # Ensure labels exist (idempotent).
-          gh label create model-changes --color FBCA04 --description "Automated alert when Bedrock catalog model/profile availability changes" --force >/dev/null
+          # Ensure the `automated` label exists (idempotent) for the PR.
           gh label create automated --color EDEDED --description "Opened by automation" --force >/dev/null
 
-          # Create the tracking issue first; capture URL to link from the PR.
-          # Issue creation does not require the "Allow Actions to create PRs"
-          # repo setting, so this still fires even if PR creation is blocked.
-          ISSUE_URL=$(gh issue create \
-            --title "$(cat /tmp/issue-title.txt)" \
-            --body-file /tmp/issue-body.md \
-            --label model-changes,automated)
-
-          # PR body references the issue.
           {
             echo "Automated nightly refresh of \`public/data.json\` from the AWS Bedrock APIs."
             echo ""
-            echo "Model availability changes tracked in ${ISSUE_URL}."
+            echo "Model availability changes are published as a GitHub Release (tag \`data-YYYY-MM-DD\`) by the \`release-data\` workflow once this PR auto-merges. See \`releases.atom\` for an RSS feed of catalog changes."
             echo ""
             echo "This PR only modifies \`public/data.json\`. Auto-merge is enabled; it will squash-merge once required checks pass."
           } > /tmp/pr-body.md
@@ -146,7 +135,7 @@ jobs:
             --title "chore(data): nightly refresh ${DATE}" \
             --body-file /tmp/pr-body.md \
             --label automated; then
-            echo "::error::gh pr create failed. Most likely cause: the repo setting 'Allow GitHub Actions to create and approve pull requests' is OFF. Enable it at: Settings -> Actions -> General -> Workflow permissions. The orphan branch ${BRANCH} will be deleted automatically; the tracking issue ${ISSUE_URL} remains as a record of the catalog change."
+            echo "::error::gh pr create failed. Most likely cause: the repo setting 'Allow GitHub Actions to create and approve pull requests' is OFF. Enable it at: Settings -> Actions -> General -> Workflow permissions. The orphan branch ${BRANCH} will be deleted automatically."
             exit 1
           fi
           PR_CREATED=1

--- a/.github/workflows/release-data.yml
+++ b/.github/workflows/release-data.yml
@@ -19,10 +19,12 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
+      # fetch-depth 50 is enough to find the previous public/data.json-touching
+      # commit even if non-data commits land between two nightly refreshes.
       - uses: actions/checkout@v5
         with:
           ref: main
-          fetch-depth: 2
+          fetch-depth: 50
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -31,59 +33,98 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Short-circuit if data.json unchanged in last commit
-        id: check
+      # Resolve the actual commits that bound the most recent data.json change,
+      # not the positional HEAD~1..HEAD pair. This avoids two failure modes:
+      #
+      #   (P1) On a no-change night refresh-data still completes successfully and
+      #        fires this workflow. If we keyed off (date -u) the tag, we would
+      #        re-release yesterday's diff under today's date. Tagging from the
+      #        commit's own date makes the idempotency check naturally correct.
+      #
+      #   (P2) If anything unrelated lands on main between refresh-data
+      #        completing and this job starting, HEAD~1..HEAD no longer
+      #        straddles the data change. Walking `git log -- public/data.json`
+      #        finds the right pair regardless of what HEAD is.
+      - name: Resolve last + previous data.json commits
+        id: commits
         run: |
           set -euo pipefail
-          if git diff --quiet HEAD~1 HEAD -- public/data.json; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "No change to public/data.json in HEAD; skipping release." >> "$GITHUB_STEP_SUMMARY"
+          LAST=$(git log -n 1 --format=%H -- public/data.json || true)
+          if [ -z "$LAST" ]; then
+            echo "No public/data.json history reachable; skipping."
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          PREV=$(git log -n 2 --format=%H -- public/data.json | tail -n 1)
+          if [ "$PREV" = "$LAST" ]; then
+            echo "Only one data.json commit reachable; nothing to diff against."
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          TAG="data-$(git log -1 --format=%cs "$LAST")"
+          echo "last=$LAST" >> "$GITHUB_OUTPUT"
+          echo "prev=$PREV" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "ready=true" >> "$GITHUB_OUTPUT"
+          echo "Last data commit: $LAST" >> "$GITHUB_STEP_SUMMARY"
+          echo "Previous data commit: $PREV" >> "$GITHUB_STEP_SUMMARY"
+          echo "Proposed tag: $TAG" >> "$GITHUB_STEP_SUMMARY"
+
+      # Cheap pre-check before we do any work — if the tag already exists, the
+      # last data commit has been released and there is nothing to do.
+      - name: Skip if release already exists for this commit
+        if: steps.commits.outputs.ready == 'true'
+        id: gate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="${{ steps.commits.outputs.tag }}"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "::notice::Release ${TAG} already exists for commit ${{ steps.commits.outputs.last }}; skipping."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
           else
-            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Build diff against previous commit
-        if: steps.check.outputs.changed == 'true'
+      - name: Build diff between previous and last data commits
+        if: steps.gate.outputs.proceed == 'true'
         id: diff
         run: |
           set -euo pipefail
-          git show HEAD~1:public/data.json > /tmp/previous.json
-          RESULT=$(bun run scripts/diff-data.ts /tmp/previous.json public/data.json)
+          git show "${{ steps.commits.outputs.prev }}:public/data.json" > /tmp/previous.json
+          git show "${{ steps.commits.outputs.last }}:public/data.json" > /tmp/current.json
+          RESULT=$(bun run scripts/diff-data.ts /tmp/previous.json /tmp/current.json)
           HAS=$(echo "$RESULT" | jq -r .hasChanges)
           if [ "$HAS" != "true" ]; then
-            # Defensive: data.json bytes changed but diff-data considers them semantically equal
-            # (e.g. only generatedAt timestamp moved). No release in that case.
-            echo "::notice::data.json bytes changed but diff-data.ts found no semantic change; skipping release."
+            # data.json bytes changed but diff-data.ts considers them
+            # semantically equal (e.g. only generatedAt moved). No release.
+            echo "::notice::data.json bytes changed between commits but diff-data.ts found no semantic change; skipping release."
             echo "release=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           echo "$RESULT" | jq -r .title > /tmp/release-title.txt
           echo "$RESULT" | jq -r .body  > /tmp/release-body.md
-          echo "tag=data-$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
           echo "release=true" >> "$GITHUB_OUTPUT"
           {
             echo "## Release candidate"
             echo ""
-            echo "**Tag:** \`data-$(date -u +%Y-%m-%d)\`"
+            echo "**Tag:** \`${{ steps.commits.outputs.tag }}\`"
             echo ""
             echo "**Title:** $(cat /tmp/release-title.txt)"
             echo ""
             cat /tmp/release-body.md
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Create release (idempotent)
-        if: steps.check.outputs.changed == 'true' && steps.diff.outputs.release == 'true'
+      - name: Create release
+        if: steps.gate.outputs.proceed == 'true' && steps.diff.outputs.release == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          TAG="${{ steps.diff.outputs.tag }}"
-          if gh release view "$TAG" >/dev/null 2>&1; then
-            echo "::notice::Release ${TAG} already exists; skipping."
-            exit 0
-          fi
+          TAG="${{ steps.commits.outputs.tag }}"
           gh release create "$TAG" \
-            --target main \
+            --target "${{ steps.commits.outputs.last }}" \
             --title "$(cat /tmp/release-title.txt)" \
             --notes-file /tmp/release-body.md
-          echo "::notice::Created release ${TAG}."
+          echo "::notice::Created release ${TAG} on commit ${{ steps.commits.outputs.last }}."

--- a/.github/workflows/release-data.yml
+++ b/.github/workflows/release-data.yml
@@ -1,0 +1,89 @@
+name: Cut release on data change
+
+on:
+  workflow_run:
+    workflows: ["Refresh Bedrock catalog"]
+    types:
+      - completed
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-data
+  cancel-in-progress: false
+
+jobs:
+  release:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 2
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Short-circuit if data.json unchanged in last commit
+        id: check
+        run: |
+          set -euo pipefail
+          if git diff --quiet HEAD~1 HEAD -- public/data.json; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No change to public/data.json in HEAD; skipping release." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build diff against previous commit
+        if: steps.check.outputs.changed == 'true'
+        id: diff
+        run: |
+          set -euo pipefail
+          git show HEAD~1:public/data.json > /tmp/previous.json
+          RESULT=$(bun run scripts/diff-data.ts /tmp/previous.json public/data.json)
+          HAS=$(echo "$RESULT" | jq -r .hasChanges)
+          if [ "$HAS" != "true" ]; then
+            # Defensive: data.json bytes changed but diff-data considers them semantically equal
+            # (e.g. only generatedAt timestamp moved). No release in that case.
+            echo "::notice::data.json bytes changed but diff-data.ts found no semantic change; skipping release."
+            echo "release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "$RESULT" | jq -r .title > /tmp/release-title.txt
+          echo "$RESULT" | jq -r .body  > /tmp/release-body.md
+          echo "tag=data-$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+          echo "release=true" >> "$GITHUB_OUTPUT"
+          {
+            echo "## Release candidate"
+            echo ""
+            echo "**Tag:** \`data-$(date -u +%Y-%m-%d)\`"
+            echo ""
+            echo "**Title:** $(cat /tmp/release-title.txt)"
+            echo ""
+            cat /tmp/release-body.md
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Create release (idempotent)
+        if: steps.check.outputs.changed == 'true' && steps.diff.outputs.release == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="${{ steps.diff.outputs.tag }}"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "::notice::Release ${TAG} already exists; skipping."
+            exit 0
+          fi
+          gh release create "$TAG" \
+            --target main \
+            --title "$(cat /tmp/release-title.txt)" \
+            --notes-file /tmp/release-body.md
+          echo "::notice::Created release ${TAG}."

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ bedrock-region-viewer/
 │   └── github-oidc-role.yaml     # OIDC role + Amplify app + domain
 ├── .github/workflows/
 │   ├── refresh-data.yml          # nightly: fetch -> PR -> auto-merge
+│   ├── release-data.yml          # on refresh-data success: cut GitHub Release
 │   └── deploy-amplify.yml        # on push to main: upload zip -> Amplify
 ├── scripts/fetch-data.ts         # AWS SDK -> public/data.json
 ├── public/                       # static site
@@ -123,12 +124,14 @@ gh workflow run deploy-amplify.yml
 2. Assumes `AWS_ROLE_ARN` via OIDC.
 3. Runs `bun run fetch` → writes a new `public/data.json`.
 4. Runs `bun run scripts/diff-data.ts` comparing baseline vs new. It ignores `generatedAt` and `errors` — only tracks model/profile ID set membership across `onDemand`, `regional`, and `global`.
-5. **If no model availability changes** → silent no-op. No PR, no issue, no noise.
-6. **If changes detected** → opens a GitHub **issue** summarizing the delta (aggregate + per-region breakdown) AND a PR committing the new `data.json` with auto-merge enabled. The PR body links back to the issue.
+5. **If no model availability changes** → silent no-op. No PR, no release, no noise.
+6. **If changes detected** → opens a PR committing the new `data.json` with auto-merge enabled.
 
-On merge, `deploy-amplify.yml` fires and redeploys the static bundle.
+On merge, `deploy-amplify.yml` fires and redeploys the static bundle. Independently, `release-data.yml` fires on `workflow_run` completion of `refresh-data` and — once the data PR has merged to `main` — publishes a **GitHub Release** with the change summary as release notes.
 
-### Issue format
+### Release format
+
+Tag: `data-YYYY-MM-DD` (calendar versioning — one release per change-detected day; idempotent on same-day re-runs).
 
 Title: `Bedrock catalog changes: +N models, -M models, +P profiles (YYYY-MM-DD)`
 
@@ -149,7 +152,12 @@ Body (abbreviated):
 - +global `global.anthropic.claude-opus-4-7`
 ```
 
-Subscribe to issues (or filter on the `model-changes` label) to get pinged when AWS adds or removes a model. The same markdown also lands in the workflow step summary — visible in the Actions tab without needing to click through.
+Subscribe via the Releases RSS feed to get pinged when AWS adds or removes a model:
+
+- Human-facing: <https://github.com/sjramblings/bedrock-region-viewer/releases>
+- RSS feed: <https://github.com/sjramblings/bedrock-region-viewer/releases.atom>
+
+The same markdown also lands in the workflow step summary — visible in the Actions tab without needing to click through.
 
 ### Why a PR instead of direct push
 


### PR DESCRIPTION
## Summary

Migrate the nightly model-availability notification surface from a tracking GitHub Issue to a GitHub Release. The motivation is `feed-system-aws`: subscribing to `releases.atom` gives a clean, low-volume RSS feed of catalog deltas suitable as a feed-system source. Issues' `.atom` feed isn't a good fit (too noisy, semantically different).

## Approach

Split into two workflows. `refresh-data.yml` continues to do the data fetch + auto-merged PR; a new `release-data.yml` fires on `workflow_run` completion of refresh-data, picks up the merge commit on `main`, and cuts a Release tagged `data-YYYY-MM-DD`.

This mirrors the existing `deploy-pages.yml` / `deploy-amplify.yml` pattern (also `workflow_run`-triggered) and sidesteps the auto-merge timing race entirely.

## Changes

- **`.github/workflows/refresh-data.yml`** — drop \`issues: write\` permission; remove the \`gh issue create\` step and \`model-changes\` label creation; rename the step from \"Open PR and create tracking issue\" to \"Open PR for nightly data refresh\"; update the PR body to mention the release path.
- **`.github/workflows/release-data.yml` (new)** — checks out \`main\` with fetch-depth 2, runs \`scripts/diff-data.ts\` between \`HEAD~1\` and \`HEAD\` on \`public/data.json\`, and calls \`gh release create data-YYYY-MM-DD\` with the diff body as notes. Idempotent: \`gh release view\` short-circuits if the tag exists; \`git diff --quiet HEAD~1 HEAD\` short-circuits if nothing changed.
- **`README.md`** — replace the \"Issue format\" section with a \"Release format\" section pointing at the human-facing releases page and the \`releases.atom\` RSS feed; add \`release-data.yml\` to the architecture diagram.

## Tag scheme

Calendar versioning: \`data-YYYY-MM-DD\`. Reads cleanly in an RSS feed, won't collide with future semantic versioning of the app code itself, and the date string is already produced by \`scripts/diff-data.ts\`.

## Out of scope

No \`package.json\` version-bump automation, no \`CHANGELOG.md\`, no release-please / semantic-release / changesets, no prerelease/draft flags, no signed tags, no release-asset uploads, no retroactive tagging of historical nightly commits, no changes to the deploy workflows.

## Verification

Workflow YAML parses cleanly (Bun yaml module). \`scripts/diff-data.ts\` unchanged. Smoke-tested both paths locally:

- Identical inputs → \`hasChanges: false\` (no-op path).
- Synthetic mutation (removed one on-demand model from us-east-1) → \`hasChanges: true\`, title \`Bedrock catalog changes: -1 model (YYYY-MM-DD)\`, body contains the per-region added/removed breakdown unchanged.

To validate end-to-end after merge:

1. Run \`gh workflow run refresh-data.yml\` (or wait for the nightly cron).
2. If model availability shifted, refresh-data opens a PR and auto-merges. release-data fires on workflow_run completion.
3. Confirm via \`gh release list --repo sjramblings/bedrock-region-viewer\` and \`curl -s https://github.com/sjramblings/bedrock-region-viewer/releases.atom | head -60\`.
4. Add the \`releases.atom\` URL to \`feed-system-aws\` sources.

The historical Issues remain in the repo as record; this is a migration, not a parallel-write.